### PR TITLE
Virtual Members, Serialization settings, Not Disposable Context  

### DIFF
--- a/.idea/.idea.Hateoas/.idea/contentModel.xml
+++ b/.idea/.idea.Hateoas/.idea/contentModel.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ContentModelStore">
-    <e p="C:\Users\icaro\.nuget\packages\microsoft.net.test.sdk\16.5.0\build\netcoreapp2.1" t="Include">
+    <e p="C:\Users\icaro\.nuget\packages\microsoft.net.test.sdk\16.6.1\build\netcoreapp2.1" t="Include">
       <e p="Microsoft.NET.Test.Sdk.Program.cs" t="Include" />
     </e>
-    <e p="C:\Users\icaro\.nuget\packages\microsoft.testplatform.testhost\16.5.0\build\netcoreapp2.1\x64\testhost.dll" t="Include" />
-    <e p="C:\Users\icaro\.nuget\packages\microsoft.testplatform.testhost\16.5.0\build\netcoreapp2.1\x64\testhost.exe" t="Include" />
-    <e p="C:\Users\icaro\.nuget\packages\xunit.runner.visualstudio\2.4.0\build\netcoreapp1.0\xunit.runner.reporters.netcoreapp10.dll" t="Include" />
-    <e p="C:\Users\icaro\.nuget\packages\xunit.runner.visualstudio\2.4.0\build\netcoreapp1.0\xunit.runner.utility.netcoreapp10.dll" t="Include" />
-    <e p="C:\Users\icaro\.nuget\packages\xunit.runner.visualstudio\2.4.0\build\netcoreapp1.0\xunit.runner.visualstudio.dotnetcore.testadapter.dll" t="Include" />
+    <e p="C:\Users\icaro\.nuget\packages\microsoft.testplatform.testhost\16.6.1\build\netcoreapp2.1\x64\testhost.dll" t="Include" />
+    <e p="C:\Users\icaro\.nuget\packages\microsoft.testplatform.testhost\16.6.1\build\netcoreapp2.1\x64\testhost.exe" t="Include" />
     <e p="C:\Users\icaro\.nuget\packages\xunit.runner.visualstudio\2.4.1\build\_common\xunit.abstractions.dll" t="Include" />
     <e p="C:\Users\icaro\.nuget\packages\xunit.runner.visualstudio\2.4.1\build\_common\xunit.runner.reporters.net452.dll" t="Include" />
     <e p="C:\Users\icaro\.nuget\packages\xunit.runner.visualstudio\2.4.1\build\_common\xunit.runner.utility.net452.dll" t="Include" />
@@ -48,6 +45,12 @@
         <e p="HateoasNet.csproj" t="IncludeRecursive" />
         <e p="obj" t="ExcludeRecursive">
           <e p="Debug" t="Include">
+            <e p="net472" t="Include">
+              <e p="HateoasNet.AssemblyInfo.cs" t="Include" />
+            </e>
+            <e p="netcoreapp3.1" t="Include">
+              <e p="HateoasNet.AssemblyInfo.cs" t="Include" />
+            </e>
             <e p="netstandard2.0" t="Include">
               <e p="HateoasNet.AssemblyInfo.cs" t="Include" />
             </e>
@@ -141,9 +144,12 @@
       <e p="HateoasNet.Core.Tests" t="IncludeRecursive">
         <e p="bin" t="ExcludeRecursive" />
         <e p="Factories" t="Include">
-          <e p="ResourceLinkFactoryTests" t="Include">
-            <e p="ResourceLinkFactoryShould.cs" t="Include" />
-          </e>
+          <e p="CreateResourceLinkDataAttribute.cs" t="Include" />
+          <e p="ResourceLinkFactoryTests.cs" t="Include" />
+        </e>
+        <e p="Formatting" t="Include">
+          <e p="FormattingDataAttribute.cs" t="Include" />
+          <e p="HateoasFormatterTests.cs" t="Include" />
         </e>
         <e p="HateoasNet.Core.Tests.csproj" t="IncludeRecursive" />
         <e p="obj" t="ExcludeRecursive">
@@ -153,8 +159,13 @@
             </e>
           </e>
         </e>
-        <e p="TestHelpers" t="Include">
-          <e p="CreateResourceLinkDataAttribute.cs" t="Include" />
+        <e p="Serialization" t="Include">
+          <e p="AddConverterDataAttribute.cs" t="Include" />
+          <e p="EnumerableResource.json" t="Include" />
+          <e p="HateoasSerializerTests.cs" t="Include" />
+          <e p="PaginationResource.json" t="Include" />
+          <e p="SerializationDataAttribute.cs" t="Include" />
+          <e p="SingleResource.json" t="Include" />
         </e>
       </e>
       <e p="HateoasNet.Framework" t="IncludeRecursive">
@@ -167,7 +178,7 @@
           <e p="ResourceLinkFactory.cs" t="Include" />
         </e>
         <e p="Formatting" t="Include">
-          <e p="HateoasFormatter.cs" t="Include" />
+          <e p="HateoasMediaTypeFormatter.cs" t="Include" />
         </e>
         <e p="HateoasNet.Framework.csproj" t="IncludeRecursive" />
         <e p="obj" t="ExcludeRecursive" />
@@ -230,15 +241,16 @@
         <e p="app.config" t="Include" />
         <e p="bin" t="ExcludeRecursive" />
         <e p="Factories" t="Include">
-          <e p="HttpMethodFinderTests" t="Include">
-            <e p="HttpMethodFinderShould.cs" t="Include" />
-          </e>
-          <e p="ResourceLinkFactoryTests" t="Include">
-            <e p="ResourceLinkFactoryShould.cs" t="Include" />
-          </e>
-          <e p="UrlBuilderTests" t="Include">
-            <e p="UrlBuilderShould.cs" t="Include" />
-          </e>
+          <e p="ResourceLinkFactoryTestData.cs" t="Include" />
+          <e p="ResourceLinkFactoryTests.cs" t="Include" />
+          <e p="TestActionDescriptor.cs" t="Include" />
+          <e p="TestControllerDescriptor.cs" t="Include" />
+          <e p="TestMethodInfo.cs" t="Include" />
+          <e p="UrlResourceLinkDataAttribute.cs" t="Include" />
+        </e>
+        <e p="Formatting" t="Include">
+          <e p="FormattingDataAttribute.cs" t="Include" />
+          <e p="HateoasFormatterTests.cs" t="Include" />
         </e>
         <e p="HateoasNet.Framework.Tests.csproj" t="IncludeRecursive" />
         <e p="obj" t="ExcludeRecursive" />
@@ -246,35 +258,28 @@
         <e p="Properties" t="Include">
           <e p="AssemblyInfo.cs" t="Include" />
         </e>
-        <e p="TestHelpers" t="Include">
-          <e p="ResourceLinkFactoryTestData.cs" t="Include" />
-          <e p="TestActionDescriptor.cs" t="Include" />
-          <e p="TestMethodInfo.cs" t="Include" />
-          <e p="UrlResourceLinkDataAttribute.cs" t="Include" />
+        <e p="Serialization" t="Include">
+          <e p="EnumerableResource.json" t="Include" />
+          <e p="HateoasSerializerTests.cs" t="Include" />
+          <e p="PaginationResource.json" t="Include" />
+          <e p="SerializationDataAttribute.cs" t="Include" />
+          <e p="SingleResource.json" t="Include" />
         </e>
       </e>
       <e p="HateoasNet.Tests" t="IncludeRecursive">
         <e p="bin" t="ExcludeRecursive" />
         <e p="Configurations" t="Include">
-          <e p="HateoasContextTests" t="Include">
-            <e p="HateoasContextShould.cs" t="Include" />
-            <e p="HateoasContextThrows.cs" t="Include" />
-          </e>
+          <e p="HateoasContextTests.cs" t="Include" />
           <e p="HateoasLinkTests" t="Include">
+            <e p="HasConditionalDataAttribute.cs" t="Include" />
             <e p="HateoasLinkCollectionFixture.cs" t="Include" />
             <e p="HateoasLinkFixture.cs" t="Include" />
             <e p="HateoasLinkShould.cs" t="Include" />
-            <e p="HateoasLinkThrows.cs" t="Include" />
           </e>
-          <e p="HateoasResourceTests" t="Include">
-            <e p="HateoasResourceShould.cs" t="Include" />
-            <e p="HateoasResourceThrows.cs" t="Include" />
-          </e>
+          <e p="HateoasResourceTests.cs" t="Include" />
         </e>
         <e p="Factories" t="Include">
-          <e p="ResourceFactoryTests" t="Include">
-            <e p="ResourceFactoryShould.cs" t="Include" />
-          </e>
+          <e p="ResourceFactoryTests.cs" t="Include" />
         </e>
         <e p="HateoasNet.Tests.csproj" t="IncludeRecursive" />
         <e p="obj" t="ExcludeRecursive">

--- a/.idea/.idea.Hateoas/riderModule.iml
+++ b/.idea/.idea.Hateoas/riderModule.iml
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="RIDER_MODULE" version="4">
   <component name="NewModuleRootManager">
-    <content url="file://$USER_HOME$/.nuget/packages/microsoft.net.test.sdk/16.5.0/build/netcoreapp2.1" />
-    <content url="file://$USER_HOME$/.nuget/packages/microsoft.testplatform.testhost/16.5.0/build/netcoreapp2.1/x64/testhost.dll" />
-    <content url="file://$USER_HOME$/.nuget/packages/microsoft.testplatform.testhost/16.5.0/build/netcoreapp2.1/x64/testhost.exe" />
-    <content url="file://$USER_HOME$/.nuget/packages/xunit.runner.visualstudio/2.4.0/build/netcoreapp1.0/xunit.runner.reporters.netcoreapp10.dll" />
-    <content url="file://$USER_HOME$/.nuget/packages/xunit.runner.visualstudio/2.4.0/build/netcoreapp1.0/xunit.runner.utility.netcoreapp10.dll" />
-    <content url="file://$USER_HOME$/.nuget/packages/xunit.runner.visualstudio/2.4.0/build/netcoreapp1.0/xunit.runner.visualstudio.dotnetcore.testadapter.dll" />
+    <content url="file://$USER_HOME$/.nuget/packages/microsoft.net.test.sdk/16.6.1/build/netcoreapp2.1" />
+    <content url="file://$USER_HOME$/.nuget/packages/microsoft.testplatform.testhost/16.6.1/build/netcoreapp2.1/x64/testhost.dll" />
+    <content url="file://$USER_HOME$/.nuget/packages/microsoft.testplatform.testhost/16.6.1/build/netcoreapp2.1/x64/testhost.exe" />
     <content url="file://$USER_HOME$/.nuget/packages/xunit.runner.visualstudio/2.4.1/build/_common/xunit.abstractions.dll" />
     <content url="file://$USER_HOME$/.nuget/packages/xunit.runner.visualstudio/2.4.1/build/_common/xunit.runner.reporters.net452.dll" />
     <content url="file://$USER_HOME$/.nuget/packages/xunit.runner.visualstudio/2.4.1/build/_common/xunit.runner.utility.net452.dll" />

--- a/HateoasNet.Core.Sample/Controllers/GuildsController.cs
+++ b/HateoasNet.Core.Sample/Controllers/GuildsController.cs
@@ -1,46 +1,46 @@
-﻿using HateoasNet.Core.Sample.JsonData;
-using HateoasNet.Core.Sample.Models;
-using Microsoft.AspNetCore.Mvc;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using HateoasNet.Core.Sample.JsonData;
+using HateoasNet.Core.Sample.Models;
+using Microsoft.AspNetCore.Mvc;
 
 namespace HateoasNet.Core.Sample.Controllers
 {
-    [ApiController]
-    [Route("[controller]")]
-    public class GuildsController : ControllerBase
-    {
-        private readonly List<Guild> _guilds;
+	[ApiController]
+	[Route("[controller]")]
+	public class GuildsController : ControllerBase
+	{
+		private readonly List<Guild> _guilds;
 
-        public GuildsController(Seeder seeder)
-        {
-            _guilds = seeder.Seed<Guild>();
-        }
+		public GuildsController(Seeder seeder)
+		{
+			_guilds = seeder.Seed<Guild>();
+		}
 
-        [HttpGet("{id:Guid}", Name = "get-guild")]
-        public IActionResult Get(Guid id)
-        {
-            var guild = _guilds.SingleOrDefault(i => i.Id == id);
-            return guild != null ? Ok(guild) : NotFound() as IActionResult;
-        }
+		[HttpGet("{id:Guid}", Name = "get-guild")]
+		public IActionResult Get(Guid id)
+		{
+			var guild = _guilds.SingleOrDefault(i => i.Id == id);
+			return guild != null ? Ok(guild) : NotFound() as IActionResult;
+		}
 
-        [HttpGet(Name = "get-guilds")]
-        public IActionResult Get()
-        {
-            return Ok(_guilds);
-        }
+		[HttpGet(Name = "get-guilds")]
+		public IActionResult Get()
+		{
+			return Ok(_guilds);
+		}
 
-        [HttpPost(Name = "create-guild")]
-        public IActionResult Post([FromBody] Guild guild)
-        {
-            return CreatedAtRoute("get-guild", new { id = guild.Id }, guild);
-        }
+		[HttpPost(Name = "create-guild")]
+		public IActionResult Post([FromBody] Guild guild)
+		{
+			return CreatedAtRoute("get-guild", new {id = guild.Id}, guild);
+		}
 
-        [HttpPut("{id:Guid}", Name = "update-guild")]
-        public IActionResult Put([FromBody] Guild guild)
-        {
-            return Ok(guild);
-        }
-    }
+		[HttpPut("{id:Guid}", Name = "update-guild")]
+		public IActionResult Put([FromBody] Guild guild)
+		{
+			return Ok(guild);
+		}
+	}
 }

--- a/HateoasNet.Core.Sample/Controllers/InvitesController.cs
+++ b/HateoasNet.Core.Sample/Controllers/InvitesController.cs
@@ -1,68 +1,68 @@
-﻿using HateoasNet.Core.Sample.JsonData;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using HateoasNet.Core.Sample.JsonData;
 using HateoasNet.Core.Sample.Models;
 using HateoasNet.Resources;
 using Microsoft.AspNetCore.Mvc;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace HateoasNet.Core.Sample.Controllers
 {
-    [ApiController]
-    [Route("[controller]")]
-    public class InvitesController : ControllerBase
-    {
-        private readonly List<Invite> _invites;
+	[ApiController]
+	[Route("[controller]")]
+	public class InvitesController : ControllerBase
+	{
+		private readonly List<Invite> _invites;
 
-        public InvitesController(Seeder seeder)
-        {
-            _invites = seeder.Seed<Invite>();
-        }
+		public InvitesController(Seeder seeder)
+		{
+			_invites = seeder.Seed<Invite>();
+		}
 
-        [HttpGet("{id:Guid}", Name = "get-invite")]
-        public IActionResult Get(Guid id)
-        {
-            var invite = _invites.SingleOrDefault(i => i.Id == id);
-            return invite != null ? Ok(invite) : NotFound() as IActionResult;
-        }
+		[HttpGet("{id:Guid}", Name = "get-invite")]
+		public IActionResult Get(Guid id)
+		{
+			var invite = _invites.SingleOrDefault(i => i.Id == id);
+			return invite != null ? Ok(invite) : NotFound() as IActionResult;
+		}
 
-        [HttpGet(Name = "get-invites")]
-        public IActionResult Get([FromQuery(Name = "pageSize")] int pageSize = 5)
-        {
-            return Ok(new Pagination<Invite>(_invites.Take(pageSize), _invites.Count, pageSize));
-        }
+		[HttpGet(Name = "get-invites")]
+		public IActionResult Get([FromQuery(Name = "pageSize")] int pageSize = 5)
+		{
+			return Ok(new Pagination<Invite>(_invites.Take(pageSize), _invites.Count, pageSize));
+		}
 
-        [HttpPost(Name = "invite-member")]
-        public IActionResult Post([FromBody] Invite invite)
-        {
-            return CreatedAtRoute("get-invite", new { id = invite.Id }, invite);
-        }
+		[HttpPost(Name = "invite-member")]
+		public IActionResult Post([FromBody] Invite invite)
+		{
+			return CreatedAtRoute("get-invite", new {id = invite.Id}, invite);
+		}
 
-        [HttpPatch("{id}/accept", Name = "accept-invite")]
-        public IActionResult Accept(Guid id)
-        {
-            var invite = _invites.SingleOrDefault(i => i.Id == id);
-            if (invite == null) return NotFound();
-            invite.Status = InviteStatuses.Accepted;
-            return Ok(invite);
-        }
+		[HttpPatch("{id}/accept", Name = "accept-invite")]
+		public IActionResult Accept(Guid id)
+		{
+			var invite = _invites.SingleOrDefault(i => i.Id == id);
+			if (invite == null) return NotFound();
+			invite.Status = InviteStatuses.Accepted;
+			return Ok(invite);
+		}
 
-        [HttpPatch("{id}/decline", Name = "decline-invite")]
-        public IActionResult Decline(Guid id)
-        {
-            var invite = _invites.SingleOrDefault(i => i.Id == id);
-            if (invite == null) return NotFound();
-            invite.Status = InviteStatuses.Declined;
-            return Ok(invite);
-        }
+		[HttpPatch("{id}/decline", Name = "decline-invite")]
+		public IActionResult Decline(Guid id)
+		{
+			var invite = _invites.SingleOrDefault(i => i.Id == id);
+			if (invite == null) return NotFound();
+			invite.Status = InviteStatuses.Declined;
+			return Ok(invite);
+		}
 
-        [HttpPatch("{id}/cancel", Name = "cancel-invite")]
-        public IActionResult Cancel(Guid id)
-        {
-            var invite = _invites.SingleOrDefault(i => i.Id == id);
-            if (invite == null) return NotFound();
-            invite.Status = InviteStatuses.Canceled;
-            return Ok(invite);
-        }
-    }
+		[HttpPatch("{id}/cancel", Name = "cancel-invite")]
+		public IActionResult Cancel(Guid id)
+		{
+			var invite = _invites.SingleOrDefault(i => i.Id == id);
+			if (invite == null) return NotFound();
+			invite.Status = InviteStatuses.Canceled;
+			return Ok(invite);
+		}
+	}
 }

--- a/HateoasNet.Core.Sample/Controllers/MembersController.cs
+++ b/HateoasNet.Core.Sample/Controllers/MembersController.cs
@@ -1,75 +1,75 @@
-﻿using HateoasNet.Core.Sample.JsonData;
-using HateoasNet.Core.Sample.Models;
-using Microsoft.AspNetCore.Mvc;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using HateoasNet.Core.Sample.JsonData;
+using HateoasNet.Core.Sample.Models;
+using Microsoft.AspNetCore.Mvc;
 
 namespace HateoasNet.Core.Sample.Controllers
 {
-    [ApiController]
-    [Route("[controller]")]
-    public class MembersController : ControllerBase
-    {
-        private readonly List<Member> _members;
+	[ApiController]
+	[Route("[controller]")]
+	public class MembersController : ControllerBase
+	{
+		private readonly List<Member> _members;
 
-        public MembersController(Seeder seeder)
-        {
-            _members = seeder.Seed<Member>();
-        }
+		public MembersController(Seeder seeder)
+		{
+			_members = seeder.Seed<Member>();
+		}
 
-        [HttpGet("{id:Guid}", Name = "get-member")]
-        public IActionResult Get(Guid id)
-        {
-            var member = _members.SingleOrDefault(i => i.Id == id);
-            return member != null ? Ok(member) : NotFound() as IActionResult;
-        }
+		[HttpGet("{id:Guid}", Name = "get-member")]
+		public IActionResult Get(Guid id)
+		{
+			var member = _members.SingleOrDefault(i => i.Id == id);
+			return member != null ? Ok(member) : NotFound() as IActionResult;
+		}
 
-        [HttpGet(Name = "get-members")]
-        public IActionResult GetAll([FromQuery] Guid guildId)
-        {
-            var members = _members.Where(m => m.GuildId == guildId || guildId == Guid.Empty).ToList();
-            return Ok(members);
-        }
+		[HttpGet(Name = "get-members")]
+		public IActionResult GetAll([FromQuery] Guid guildId)
+		{
+			var members = _members.Where(m => m.GuildId == guildId || guildId == Guid.Empty).ToList();
+			return Ok(members);
+		}
 
-        [HttpPost(Name = "create-member")]
-        public IActionResult Create([FromBody] Member member)
-        {
-            return CreatedAtRoute("get-member", new { id = member.Id }, member);
-        }
+		[HttpPost(Name = "create-member")]
+		public IActionResult Create([FromBody] Member member)
+		{
+			return CreatedAtRoute("get-member", new {id = member.Id}, member);
+		}
 
-        [HttpPut("{id:Guid}", Name = "update-member")]
-        public IActionResult Update([FromBody] Member member)
-        {
-            return Ok(member);
-        }
+		[HttpPut("{id:Guid}", Name = "update-member")]
+		public IActionResult Update([FromBody] Member member)
+		{
+			return Ok(member);
+		}
 
-        [HttpPatch("{id}/promote", Name = "promote-member")]
-        public IActionResult Promote(Guid id)
-        {
-            var member = _members.SingleOrDefault(i => i.Id == id);
-            if (member == null) return NotFound();
-            member.IsGuildMaster = true;
-            return Ok(member);
-        }
+		[HttpPatch("{id}/promote", Name = "promote-member")]
+		public IActionResult Promote(Guid id)
+		{
+			var member = _members.SingleOrDefault(i => i.Id == id);
+			if (member == null) return NotFound();
+			member.IsGuildMaster = true;
+			return Ok(member);
+		}
 
-        [HttpPatch("{id}/demote", Name = "demote-member")]
-        public IActionResult Demote(Guid id)
-        {
-            var member = _members.SingleOrDefault(i => i.Id == id);
-            if (member == null) return NotFound();
-            member.IsGuildMaster = false;
-            return Ok(member);
-        }
+		[HttpPatch("{id}/demote", Name = "demote-member")]
+		public IActionResult Demote(Guid id)
+		{
+			var member = _members.SingleOrDefault(i => i.Id == id);
+			if (member == null) return NotFound();
+			member.IsGuildMaster = false;
+			return Ok(member);
+		}
 
-        [HttpPatch("{id}/leave", Name = "leave-guild")]
-        public IActionResult LeaveGuild(Guid id)
-        {
-            var member = _members.SingleOrDefault(i => i.Id == id);
-            if (member == null) return NotFound();
-            member.Guild = null;
-            member.GuildId = null;
-            return Ok(member);
-        }
-    }
+		[HttpPatch("{id}/leave", Name = "leave-guild")]
+		public IActionResult LeaveGuild(Guid id)
+		{
+			var member = _members.SingleOrDefault(i => i.Id == id);
+			if (member == null) return NotFound();
+			member.Guild = null;
+			member.GuildId = null;
+			return Ok(member);
+		}
+	}
 }

--- a/HateoasNet.Core.Sample/HateoasConfigurations/GuildHateoasConfiguration.cs
+++ b/HateoasNet.Core.Sample/HateoasConfigurations/GuildHateoasConfiguration.cs
@@ -3,13 +3,13 @@ using HateoasNet.Core.Sample.Models;
 
 namespace HateoasNet.Core.Sample.HateoasConfigurations
 {
-    public class GuildHateoasConfiguration : IHateoasResourceConfiguration<Guild>
-    {
-        public void Configure(IHateoasResource<Guild> resource)
-        {
-            resource.HasLink("get-guild").HasRouteData(g => new { id = g.Id });
-            resource.HasLink("get-members").HasRouteData(g => new { guildId = g.Id });
-            resource.HasLink("update-guild").HasRouteData(e => new { id = e.Id });
-        }
-    }
+	public class GuildHateoasConfiguration : IHateoasResourceConfiguration<Guild>
+	{
+		public void Configure(IHateoasResource<Guild> resource)
+		{
+			resource.HasLink("get-guild").HasRouteData(g => new {id = g.Id});
+			resource.HasLink("get-members").HasRouteData(g => new {guildId = g.Id});
+			resource.HasLink("update-guild").HasRouteData(e => new {id = e.Id});
+		}
+	}
 }

--- a/HateoasNet.Core.Sample/HateoasConfigurations/InviteHateoasConfiguration.cs
+++ b/HateoasNet.Core.Sample/HateoasConfigurations/InviteHateoasConfiguration.cs
@@ -3,25 +3,25 @@ using HateoasNet.Core.Sample.Models;
 
 namespace HateoasNet.Core.Sample.HateoasConfigurations
 {
-    public class InviteHateoasConfiguration : IHateoasResourceConfiguration<Invite>
-    {
-        public void Configure(IHateoasResource<Invite> resource)
-        {
-            resource.HasLink("accept-invite")
-                    .HasRouteData(e => new { id = e.Id })
-                    .HasConditional(e => e.Status == InviteStatuses.Pending);
+	public class InviteHateoasConfiguration : IHateoasResourceConfiguration<Invite>
+	{
+		public void Configure(IHateoasResource<Invite> resource)
+		{
+			resource.HasLink("accept-invite")
+			        .HasRouteData(e => new {id = e.Id})
+			        .HasConditional(e => e.Status == InviteStatuses.Pending);
 
-            resource.HasLink("decline-invite")
-                    .HasRouteData(e => new { id = e.Id })
-                    .HasConditional(e => e.Status == InviteStatuses.Pending);
+			resource.HasLink("decline-invite")
+			        .HasRouteData(e => new {id = e.Id})
+			        .HasConditional(e => e.Status == InviteStatuses.Pending);
 
-            resource.HasLink("cancel-invite")
-                    .HasRouteData(e => new { id = e.Id })
-                    .HasConditional(e => e.Status == InviteStatuses.Pending);
+			resource.HasLink("cancel-invite")
+			        .HasRouteData(e => new {id = e.Id})
+			        .HasConditional(e => e.Status == InviteStatuses.Pending);
 
-            resource.HasLink("get-invite").HasRouteData(i => new { id = i.Id });
-            resource.HasLink("get-guild").HasRouteData(i => new { id = i.GuildId });
-            resource.HasLink("get-member").HasRouteData(i => new { id = i.MemberId });
-        }
-    }
+			resource.HasLink("get-invite").HasRouteData(i => new {id = i.Id});
+			resource.HasLink("get-guild").HasRouteData(i => new {id = i.GuildId});
+			resource.HasLink("get-member").HasRouteData(i => new {id = i.MemberId});
+		}
+	}
 }

--- a/HateoasNet.Core.Sample/HateoasConfigurations/ListGuildHateoasConfiguration.cs
+++ b/HateoasNet.Core.Sample/HateoasConfigurations/ListGuildHateoasConfiguration.cs
@@ -1,15 +1,15 @@
-﻿using HateoasNet.Abstractions;
+﻿using System.Collections.Generic;
+using HateoasNet.Abstractions;
 using HateoasNet.Core.Sample.Models;
-using System.Collections.Generic;
 
 namespace HateoasNet.Core.Sample.HateoasConfigurations
 {
-    public class ListGuildHateoasConfiguration : IHateoasResourceConfiguration<List<Guild>>
-    {
-        public void Configure(IHateoasResource<List<Guild>> resource)
-        {
-            resource.HasLink("get-guilds");
-            resource.HasLink("create-guild");
-        }
-    }
+	public class ListGuildHateoasConfiguration : IHateoasResourceConfiguration<List<Guild>>
+	{
+		public void Configure(IHateoasResource<List<Guild>> resource)
+		{
+			resource.HasLink("get-guilds");
+			resource.HasLink("create-guild");
+		}
+	}
 }

--- a/HateoasNet.Core.Sample/HateoasConfigurations/ListMemberHateoasConfiguration.cs
+++ b/HateoasNet.Core.Sample/HateoasConfigurations/ListMemberHateoasConfiguration.cs
@@ -1,16 +1,16 @@
-﻿using HateoasNet.Abstractions;
+﻿using System.Collections.Generic;
+using HateoasNet.Abstractions;
 using HateoasNet.Core.Sample.Models;
-using System.Collections.Generic;
 
 namespace HateoasNet.Core.Sample.HateoasConfigurations
 {
-    public class ListMemberHateoasConfiguration : IHateoasResourceConfiguration<List<Member>>
-    {
-        public void Configure(IHateoasResource<List<Member>> resource)
-        {
-            resource.HasLink("get-members");
-            resource.HasLink("invite-member");
-            resource.HasLink("create-member");
-        }
-    }
+	public class ListMemberHateoasConfiguration : IHateoasResourceConfiguration<List<Member>>
+	{
+		public void Configure(IHateoasResource<List<Member>> resource)
+		{
+			resource.HasLink("get-members");
+			resource.HasLink("invite-member");
+			resource.HasLink("create-member");
+		}
+	}
 }

--- a/HateoasNet.Core.Sample/HateoasConfigurations/MemberHateoasConfiguration.cs
+++ b/HateoasNet.Core.Sample/HateoasConfigurations/MemberHateoasConfiguration.cs
@@ -3,31 +3,31 @@ using HateoasNet.Core.Sample.Models;
 
 namespace HateoasNet.Core.Sample.HateoasConfigurations
 {
-    public class MemberHateoasConfiguration : IHateoasResourceConfiguration<Member>
-    {
-        public void Configure(IHateoasResource<Member> resource)
-        {
-            resource.HasLink("get-member").HasRouteData(e => new { id = e.Id });
-            resource.HasLink("update-member").HasRouteData(e => new { id = e.Id });
+	public class MemberHateoasConfiguration : IHateoasResourceConfiguration<Member>
+	{
+		public void Configure(IHateoasResource<Member> resource)
+		{
+			resource.HasLink("get-member").HasRouteData(e => new {id = e.Id});
+			resource.HasLink("update-member").HasRouteData(e => new {id = e.Id});
 
-            resource
-                .HasLink("get-guild")
-                .HasRouteData(e => new { id = e.GuildId })
-                .HasConditional(e => e.GuildId != null);
+			resource
+				.HasLink("get-guild")
+				.HasRouteData(e => new {id = e.GuildId})
+				.HasConditional(e => e.GuildId != null);
 
-            resource
-                .HasLink("promote-member")
-                .HasRouteData(e => new { id = e.Id })
-                .HasConditional(e => e.GuildId != null && !e.IsGuildMaster);
+			resource
+				.HasLink("promote-member")
+				.HasRouteData(e => new {id = e.Id})
+				.HasConditional(e => e.GuildId != null && !e.IsGuildMaster);
 
-            resource
-                .HasLink("demote-member")
-                .HasRouteData(e => new { id = e.Id })
-                .HasConditional(e => e.GuildId != null && e.IsGuildMaster);
+			resource
+				.HasLink("demote-member")
+				.HasRouteData(e => new {id = e.Id})
+				.HasConditional(e => e.GuildId != null && e.IsGuildMaster);
 
-            resource.HasLink("leave-guild")
-                    .HasRouteData(e => new { id = e.Id })
-                    .HasConditional(e => e.GuildId != null);
-        }
-    }
+			resource.HasLink("leave-guild")
+			        .HasRouteData(e => new {id = e.Id})
+			        .HasConditional(e => e.GuildId != null);
+		}
+	}
 }

--- a/HateoasNet.Core.Sample/HateoasConfigurations/PaginationInviteHateoasConfiguration.cs
+++ b/HateoasNet.Core.Sample/HateoasConfigurations/PaginationInviteHateoasConfiguration.cs
@@ -4,12 +4,12 @@ using HateoasNet.Resources;
 
 namespace HateoasNet.Core.Sample.HateoasConfigurations
 {
-    public class PaginationInviteHateoasConfiguration : IHateoasResourceConfiguration<Pagination<Invite>>
-    {
-        public void Configure(IHateoasResource<Pagination<Invite>> resource)
-        {
-            resource.HasLink("get-invites");
-            resource.HasLink("invite-member");
-        }
-    }
+	public class PaginationInviteHateoasConfiguration : IHateoasResourceConfiguration<Pagination<Invite>>
+	{
+		public void Configure(IHateoasResource<Pagination<Invite>> resource)
+		{
+			resource.HasLink("get-invites");
+			resource.HasLink("invite-member");
+		}
+	}
 }

--- a/HateoasNet.Core.Sample/HateoasNet.Core.Sample.csproj
+++ b/HateoasNet.Core.Sample/HateoasNet.Core.Sample.csproj
@@ -2,8 +2,9 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
-    
+
     <ItemGroup>
       <ProjectReference Include="..\HateoasNet.Core\HateoasNet.Core.csproj" />
       <ProjectReference Include="..\HateoasNet\HateoasNet.csproj" />

--- a/HateoasNet.Core.Sample/HateoasSetupExtensions.cs
+++ b/HateoasNet.Core.Sample/HateoasSetupExtensions.cs
@@ -1,112 +1,112 @@
-﻿using HateoasNet.Core.DependencyInjection;
+﻿using System.Collections.Generic;
+using HateoasNet.Core.DependencyInjection;
 using HateoasNet.Core.Sample.HateoasConfigurations;
 using HateoasNet.Core.Sample.Models;
 using HateoasNet.Resources;
 using Microsoft.Extensions.DependencyInjection;
-using System.Collections.Generic;
 
 namespace HateoasNet.Core.Sample
 {
-    public static class HateoasSetupExtensions
-    {
-        public static IServiceCollection HateoasConfigurationUsingAssembly(this IServiceCollection services)
-        {
-            // setup applying map configurations from classes in separated files found in a given assembly
-            return services
-                .ConfigureHateoas(context => context.ConfigureFromAssembly(typeof(GuildHateoasConfiguration).Assembly));
-        }
+	public static class HateoasSetupExtensions
+	{
+		public static IServiceCollection HateoasConfigurationUsingAssembly(this IServiceCollection services)
+		{
+			// setup applying map configurations from classes in separated files found in a given assembly
+			return services
+				.ConfigureHateoas(context => context.ConfigureFromAssembly(typeof(GuildHateoasConfiguration).Assembly));
+		}
 
-        public static IServiceCollection HateoasConfigurations(this IServiceCollection services)
-        {
-            // setup applying map configurations from classes in separated files
-            return services.ConfigureHateoas(context => context
-                                                       .ApplyConfiguration(new GuildHateoasConfiguration())
-                                                       .ApplyConfiguration(new ListGuildHateoasConfiguration())
-                                                       .ApplyConfiguration(new MemberHateoasConfiguration())
-                                                       .ApplyConfiguration(new ListMemberHateoasConfiguration())
-                                                       .ApplyConfiguration(new InviteHateoasConfiguration())
-                                                       .ApplyConfiguration(new PaginationInviteHateoasConfiguration()));
-        }
+		public static IServiceCollection HateoasConfigurations(this IServiceCollection services)
+		{
+			// setup applying map configurations from classes in separated files
+			return services.ConfigureHateoas(context => context
+			                                            .ApplyConfiguration(new GuildHateoasConfiguration())
+			                                            .ApplyConfiguration(new ListGuildHateoasConfiguration())
+			                                            .ApplyConfiguration(new MemberHateoasConfiguration())
+			                                            .ApplyConfiguration(new ListMemberHateoasConfiguration())
+			                                            .ApplyConfiguration(new InviteHateoasConfiguration())
+			                                            .ApplyConfiguration(new PaginationInviteHateoasConfiguration()));
+		}
 
-        public static IServiceCollection HateoasInlineConfiguration(this IServiceCollection services)
-        {
-            return services.ConfigureHateoas(context =>
-            {
-                return context
-                       // map All Api returns of type List<Guild> to links with no routeData and no conditional predicate
-                       .Configure<List<Guild>>(guilds =>
-                       {
-                           guilds.HasLink("get-guilds");
-                           guilds.HasLink("create-guild");
-                       })
+		public static IServiceCollection HateoasInlineConfiguration(this IServiceCollection services)
+		{
+			return services.ConfigureHateoas(context =>
+			{
+				return context
+				       // map All Api returns of type List<Guild> to links with no routeData and no conditional predicate
+				       .Configure<List<Guild>>(guilds =>
+				       {
+					       guilds.HasLink("get-guilds");
+					       guilds.HasLink("create-guild");
+				       })
 
-                       // map All Api returns of type List<Member> to links with no routeData and no conditional predicate
-                       .Configure<List<Member>>(members =>
-                       {
-                           members.HasLink("get-members");
-                           members.HasLink("invite-member");
-                           members.HasLink("create-member");
-                       })
+				       // map All Api returns of type List<Member> to links with no routeData and no conditional predicate
+				       .Configure<List<Member>>(members =>
+				       {
+					       members.HasLink("get-members");
+					       members.HasLink("invite-member");
+					       members.HasLink("create-member");
+				       })
 
-                       // map type with links for Pagination with no routeData and no conditional predicate
-                       .Configure<Pagination<Invite>>(invites =>
-                       {
-                           invites.HasLink("get-invites");
-                           invites.HasLink("invite-member");
-                       })
+				       // map type with links for Pagination with no routeData and no conditional predicate
+				       .Configure<Pagination<Invite>>(invites =>
+				       {
+					       invites.HasLink("get-invites");
+					       invites.HasLink("invite-member");
+				       })
 
-                       // map type with links for single objects
-                       .Configure<Guild>(guild =>
-                       {
-                           guild.HasLink("get-guild").HasRouteData(g => new { id = g.Id });
-                           guild.HasLink("get-members").HasRouteData(g => new { guildId = g.Id });
-                           guild.HasLink("update-guild").HasRouteData(e => new { id = e.Id });
-                       })
-                       .Configure<Invite>(invite =>
-                       {
-                           invite.HasLink("accept-invite")
-                                 .HasRouteData(e => new { id = e.Id })
-                                 .HasConditional(e => e.Status == InviteStatuses.Pending);
+				       // map type with links for single objects
+				       .Configure<Guild>(guild =>
+				       {
+					       guild.HasLink("get-guild").HasRouteData(g => new {id = g.Id});
+					       guild.HasLink("get-members").HasRouteData(g => new {guildId = g.Id});
+					       guild.HasLink("update-guild").HasRouteData(e => new {id = e.Id});
+				       })
+				       .Configure<Invite>(invite =>
+				       {
+					       invite.HasLink("accept-invite")
+					             .HasRouteData(e => new {id = e.Id})
+					             .HasConditional(e => e.Status == InviteStatuses.Pending);
 
-                           invite.HasLink("decline-invite")
-                                 .HasRouteData(e => new { id = e.Id })
-                                 .HasConditional(e => e.Status == InviteStatuses.Pending);
+					       invite.HasLink("decline-invite")
+					             .HasRouteData(e => new {id = e.Id})
+					             .HasConditional(e => e.Status == InviteStatuses.Pending);
 
-                           invite.HasLink("cancel-invite")
-                                 .HasRouteData(e => new { id = e.Id })
-                                 .HasConditional(e => e.Status == InviteStatuses.Pending);
+					       invite.HasLink("cancel-invite")
+					             .HasRouteData(e => new {id = e.Id})
+					             .HasConditional(e => e.Status == InviteStatuses.Pending);
 
-                           invite.HasLink("get-invite").HasRouteData(i => new { id = i.Id });
-                           invite.HasLink("get-guild").HasRouteData(i => new { id = i.GuildId });
-                           invite.HasLink("get-member").HasRouteData(i => new { id = i.MemberId });
-                       })
-                       .Configure<Member>(member =>
-                       {
-                           member.HasLink("get-member").HasRouteData(e => new { id = e.Id });
-                           member.HasLink("update-member").HasRouteData(e => new { id = e.Id });
-                       })
-                       .Configure<Member>(member =>
-                       {
-                           member
-                               .HasLink("get-guild")
-                               .HasRouteData(e => new { id = e.GuildId })
-                               .HasConditional(e => e.GuildId != null);
+					       invite.HasLink("get-invite").HasRouteData(i => new {id = i.Id});
+					       invite.HasLink("get-guild").HasRouteData(i => new {id = i.GuildId});
+					       invite.HasLink("get-member").HasRouteData(i => new {id = i.MemberId});
+				       })
+				       .Configure<Member>(member =>
+				       {
+					       member.HasLink("get-member").HasRouteData(e => new {id = e.Id});
+					       member.HasLink("update-member").HasRouteData(e => new {id = e.Id});
+				       })
+				       .Configure<Member>(member =>
+				       {
+					       member
+						       .HasLink("get-guild")
+						       .HasRouteData(e => new {id = e.GuildId})
+						       .HasConditional(e => e.GuildId != null);
 
-                           member
-                               .HasLink("promote-member")
-                               .HasRouteData(e => new { id = e.Id })
-                               .HasConditional(e => e.GuildId != null && !e.IsGuildMaster);
+					       member
+						       .HasLink("promote-member")
+						       .HasRouteData(e => new {id = e.Id})
+						       .HasConditional(e => e.GuildId != null && !e.IsGuildMaster);
 
-                           member
-                               .HasLink("demote-member")
-                               .HasRouteData(e => new { id = e.Id })
-                               .HasConditional(e => e.GuildId != null && e.IsGuildMaster);
+					       member
+						       .HasLink("demote-member")
+						       .HasRouteData(e => new {id = e.Id})
+						       .HasConditional(e => e.GuildId != null && e.IsGuildMaster);
 
-                           member.HasLink("leave-guild")
-                                 .HasRouteData(e => new { id = e.Id })
-                                 .HasConditional(e => e.GuildId != null);
-                       });
-            });
-        }
-    }
+					       member.HasLink("leave-guild")
+					             .HasRouteData(e => new {id = e.Id})
+					             .HasConditional(e => e.GuildId != null);
+				       });
+			});
+		}
+	}
 }

--- a/HateoasNet.Core.Sample/JsonData/Seeder.cs
+++ b/HateoasNet.Core.Sample/JsonData/Seeder.cs
@@ -1,24 +1,24 @@
-﻿using HateoasNet.Core.Serialization;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using HateoasNet.Core.Serialization;
 
 namespace HateoasNet.Core.Sample.JsonData
 {
-    public class Seeder
-    {
-        internal List<T> Seed<T>() where T : class
-        {
-            var serializerOptions = new JsonSerializerOptions
-            {
-                IgnoreNullValues = true,
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-            };
-            serializerOptions.Converters.Add(new GuidConverter());
-            serializerOptions.Converters.Add(new DateTimeConverter());
+	public class Seeder
+	{
+		internal List<T> Seed<T>() where T : class
+		{
+			var serializerOptions = new JsonSerializerOptions
+			{
+				IgnoreNullValues = true,
+				PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+			};
+			serializerOptions.Converters.Add(new GuidConverter());
+			serializerOptions.Converters.Add(new DateTimeConverter());
 
-            using var stream = new StreamReader($"JsonData\\{typeof(T).Name.ToLower()}s.json");
-            return JsonSerializer.Deserialize<List<T>>(stream.ReadToEnd(), serializerOptions);
-        }
-    }
+			using var stream = new StreamReader($"JsonData\\{typeof(T).Name.ToLower()}s.json");
+			return JsonSerializer.Deserialize<List<T>>(stream.ReadToEnd(), serializerOptions);
+		}
+	}
 }

--- a/HateoasNet.Core.Sample/Models/Guild.cs
+++ b/HateoasNet.Core.Sample/Models/Guild.cs
@@ -4,11 +4,11 @@ using System.Text.Json.Serialization;
 
 namespace HateoasNet.Core.Sample.Models
 {
-    public class Guild
-    {
-        public Guid Id { get; set; } = Guid.NewGuid();
-        public string Name { get; set; }
-        [JsonIgnore] public ICollection<Member> Members { get; set; } = new List<Member>();
-        [JsonIgnore] public ICollection<Invite> Invites { get; set; } = new List<Invite>();
-    }
+	public class Guild
+	{
+		public Guid Id { get; set; } = Guid.NewGuid();
+		public string Name { get; set; }
+		[JsonIgnore] public ICollection<Member> Members { get; set; } = new List<Member>();
+		[JsonIgnore] public ICollection<Invite> Invites { get; set; } = new List<Invite>();
+	}
 }

--- a/HateoasNet.Core.Sample/Models/Invite.cs
+++ b/HateoasNet.Core.Sample/Models/Invite.cs
@@ -3,18 +3,18 @@ using System.Text.Json.Serialization;
 
 namespace HateoasNet.Core.Sample.Models
 {
-    public class Invite
-    {
-        public Guid Id { get; set; } = Guid.NewGuid();
-        public InviteStatuses Status { get; set; } = InviteStatuses.Pending;
-        public Guid GuildId { get; set; }
-        public Guid MemberId { get; set; }
-        [JsonIgnore] public Member Member { get; set; }
-        [JsonIgnore] public Guild Guild { get; set; }
-    }
+	public class Invite
+	{
+		public Guid Id { get; set; } = Guid.NewGuid();
+		public InviteStatuses Status { get; set; } = InviteStatuses.Pending;
+		public Guid GuildId { get; set; }
+		public Guid MemberId { get; set; }
+		[JsonIgnore] public Member Member { get; set; }
+		[JsonIgnore] public Guild Guild { get; set; }
+	}
 
-    public enum InviteStatuses : short
-    {
+	public enum InviteStatuses : short
+	{
         /// <summary>
         ///   Waiting for an answer as accepted, declined or canceled
         /// </summary>
@@ -34,5 +34,5 @@ namespace HateoasNet.Core.Sample.Models
         ///   Canceled by inviting guild
         /// </summary>
         Canceled
-    }
+	}
 }

--- a/HateoasNet.Core.Sample/Models/Member.cs
+++ b/HateoasNet.Core.Sample/Models/Member.cs
@@ -3,12 +3,12 @@ using System.Text.Json.Serialization;
 
 namespace HateoasNet.Core.Sample.Models
 {
-    public class Member
-    {
-        public Guid Id { get; set; } = Guid.NewGuid();
-        public string Name { get; set; }
-        public bool IsGuildMaster { get; set; }
-        public Guid? GuildId { get; set; }
-        [JsonIgnore] public Guild Guild { get; set; }
-    }
+	public class Member
+	{
+		public Guid Id { get; set; } = Guid.NewGuid();
+		public string Name { get; set; }
+		public bool IsGuildMaster { get; set; }
+		public Guid? GuildId { get; set; }
+		[JsonIgnore] public Guild Guild { get; set; }
+	}
 }

--- a/HateoasNet.Core.Sample/Program.cs
+++ b/HateoasNet.Core.Sample/Program.cs
@@ -3,17 +3,17 @@ using Microsoft.Extensions.Hosting;
 
 namespace HateoasNet.Core.Sample
 {
-    public class Program
-    {
-        public static void Main(string[] args)
-        {
-            CreateHostBuilder(args).Build().Run();
-        }
+	public class Program
+	{
+		public static void Main(string[] args)
+		{
+			CreateHostBuilder(args).Build().Run();
+		}
 
-        public static IHostBuilder CreateHostBuilder(string[] args)
-        {
-            return Host.CreateDefaultBuilder(args)
-                       .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
-        }
-    }
+		public static IHostBuilder CreateHostBuilder(string[] args)
+		{
+			return Host.CreateDefaultBuilder(args)
+			           .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
+		}
+	}
 }

--- a/HateoasNet.Core.Sample/Startup.cs
+++ b/HateoasNet.Core.Sample/Startup.cs
@@ -8,42 +8,42 @@ using Microsoft.Extensions.Hosting;
 
 namespace HateoasNet.Core.Sample
 {
-    public class Startup
-    {
-        public Startup(IConfiguration configuration)
-        {
-            Configuration = configuration;
-        }
+	public class Startup
+	{
+		public Startup(IConfiguration configuration)
+		{
+			Configuration = configuration;
+		}
 
-        public IConfiguration Configuration { get; }
+		public IConfiguration Configuration { get; }
 
-        // This method gets called by the runtime. Use this method to add services to the container.
-        public void ConfigureServices(IServiceCollection services)
-        {
-            services
-                .AddScoped<Seeder>()
-                /*
-				 * switch this lines to test different configuration styles
-				 * Check 'HateoasSetupExtensions.cs' file for details of each one
-				 */
-                //.HateoasInlineConfiguration()
-                //.HateoasConfigurations()
-                .HateoasConfigurationUsingAssembly()
+		// This method gets called by the runtime. Use this method to add services to the container.
+		public void ConfigureServices(IServiceCollection services)
+		{
+			services
+				.AddScoped<Seeder>()
+				/*
+ * switch this lines to test different configuration styles
+ * Check 'HateoasSetupExtensions.cs' file for details of each one
+ */
+				//.HateoasInlineConfiguration()
+				//.HateoasConfigurations()
+				.HateoasConfigurationUsingAssembly()
 
-                // MvcBuilder
-                .AddControllers()
-                .AddHateoasFormatter();
-        }
+				// MvcBuilder
+				.AddControllers()
+				.AddHateoasFormatter();
+		}
 
-        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
-        {
-            if (env.IsDevelopment()) app.UseDeveloperExceptionPage();
+		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+		public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+		{
+			if (env.IsDevelopment()) app.UseDeveloperExceptionPage();
 
-            app.UseHttpsRedirection()
-               .UseRouting()
-               .UseAuthorization()
-               .UseEndpoints(endpoints => { endpoints.MapControllers(); });
-        }
-    }
+			app.UseHttpsRedirection()
+			   .UseRouting()
+			   .UseAuthorization()
+			   .UseEndpoints(endpoints => { endpoints.MapControllers(); });
+		}
+	}
 }

--- a/HateoasNet.Core.Tests/Factories/CreateResourceLinkDataAttribute.cs
+++ b/HateoasNet.Core.Tests/Factories/CreateResourceLinkDataAttribute.cs
@@ -5,56 +5,56 @@ using Xunit.Sdk;
 
 namespace HateoasNet.Core.Tests.Factories
 {
-    public class CreateResourceLinkDataAttribute : DataAttribute
-    {
-        public override IEnumerable<object[]> GetData(MethodInfo testMethod)
-        {
-            var routeData = new { id = Guid.NewGuid() };
-            var routeName = "test1";
-            var url = $"http://dummy.test/api/dummy/{routeName}/{routeData.id}";
-            var method = "GET";
+	public class CreateResourceLinkDataAttribute : DataAttribute
+	{
+		public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+		{
+			var routeData = new {id = Guid.NewGuid()};
+			var routeName = "test1";
+			var url = $"http://dummy.test/api/dummy/{routeName}/{routeData.id}";
+			var method = "GET";
 
-            yield return new object[] { routeData, routeName, url, method };
+			yield return new object[] {routeData, routeName, url, method};
 
-            routeName = "test2";
-            url = $"http://dummy.test/api/dummy/{routeName}";
-            method = "POST";
+			routeName = "test2";
+			url = $"http://dummy.test/api/dummy/{routeName}";
+			method = "POST";
 
-            yield return new object[] { null, routeName, url, method };
+			yield return new object[] {null, routeName, url, method};
 
-            routeData = new { id = Guid.NewGuid() };
-            routeName = "test3";
-            url = $"http://dummy.test/api/dummy/{routeName}/{routeData.id}";
-            method = "PATCH";
+			routeData = new {id = Guid.NewGuid()};
+			routeName = "test3";
+			url = $"http://dummy.test/api/dummy/{routeName}/{routeData.id}";
+			method = "PATCH";
 
-            yield return new object[] { routeData, routeName, url, method };
+			yield return new object[] {routeData, routeName, url, method};
 
-            routeData = new { id = Guid.NewGuid() };
-            routeName = "test4";
-            url = $"http://dummy.test/api/dummy/{routeName}/{routeData.id}";
-            method = "DELETE";
+			routeData = new {id = Guid.NewGuid()};
+			routeName = "test4";
+			url = $"http://dummy.test/api/dummy/{routeName}/{routeData.id}";
+			method = "DELETE";
 
-            yield return new object[] { routeData, routeName, url, method };
+			yield return new object[] {routeData, routeName, url, method};
 
-            routeName = "test5";
-            url = $"http://dummy.test/api/dummy/{routeName}";
-            method = "PUT";
+			routeName = "test5";
+			url = $"http://dummy.test/api/dummy/{routeName}";
+			method = "PUT";
 
-            yield return new object[] { routeData, routeName, url, method };
+			yield return new object[] {routeData, routeName, url, method};
 
-            var routeData2 = new
-            {
-                id = Guid.NewGuid(),
-                label = "test",
-                page = 21,
-                pageSize = 10
-            };
-            routeName = "test6";
-            var queryString = $"?pageSize={routeData2.pageSize}&page={routeData2.page}&label={routeData2.label}";
-            url = $"http://dummy.test/api/dummy/{routeName}{queryString}";
-            method = "GET";
+			var routeData2 = new
+			{
+				id = Guid.NewGuid(),
+				label = "test",
+				page = 21,
+				pageSize = 10
+			};
+			routeName = "test6";
+			var queryString = $"?pageSize={routeData2.pageSize}&page={routeData2.page}&label={routeData2.label}";
+			url = $"http://dummy.test/api/dummy/{routeName}{queryString}";
+			method = "GET";
 
-            yield return new object[] { routeData2, routeName, url, method };
-        }
-    }
+			yield return new object[] {routeData2, routeName, url, method};
+		}
+	}
 }

--- a/HateoasNet.Core.Tests/Factories/ResourceLinkFactoryTests.cs
+++ b/HateoasNet.Core.Tests/Factories/ResourceLinkFactoryTests.cs
@@ -1,4 +1,6 @@
-﻿using HateoasNet.Abstractions;
+﻿using System;
+using System.Collections.Generic;
+using HateoasNet.Abstractions;
 using HateoasNet.Configurations;
 using HateoasNet.Core.Factories;
 using HateoasNet.Resources;
@@ -8,101 +10,99 @@ using Microsoft.AspNetCore.Mvc.ActionConstraints;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Moq;
-using System;
-using System.Collections.Generic;
 using Xunit;
 
 namespace HateoasNet.Core.Tests.Factories
 {
-    public class ResourceLinkFactoryTests : IDisposable
-    {
-        public ResourceLinkFactoryTests()
-        {
-            _mockActionDescriptorCollectionProvider = new Mock<IActionDescriptorCollectionProvider>().SetupAllProperties();
-            _mockUrlHelper = new Mock<IUrlHelper>().SetupAllProperties();
-        }
+	public class ResourceLinkFactoryTests : IDisposable
+	{
+		public ResourceLinkFactoryTests()
+		{
+			_mockActionDescriptorCollectionProvider = new Mock<IActionDescriptorCollectionProvider>().SetupAllProperties();
+			_mockUrlHelper = new Mock<IUrlHelper>().SetupAllProperties();
+		}
 
-        private readonly Mock<IUrlHelper> _mockUrlHelper;
-        private readonly Mock<IActionDescriptorCollectionProvider> _mockActionDescriptorCollectionProvider;
+		/// <inheritdoc />
+		public void Dispose()
+		{
+			GC.SuppressFinalize(this);
+		}
 
-        [Theory]
-        [CreateResourceLinkData]
-        [Trait(nameof(IResourceLinkFactory), nameof(IResourceLinkFactory.Create))]
-        public void Create_ValidParameters_ReturnsResourceLink(object data, string routeName, string url, string method)
-        {
-            // arrange
-            ActionDescriptorCollectionProviderArrangements(routeName, method);
-            var routeDictionary = data?.ToRouteDictionary(); // can be null
-            _mockUrlHelper.Setup(x => x.Link(routeName, routeDictionary)).Returns(url);
-            var sut = new ResourceLinkFactory(_mockUrlHelper.Object, _mockActionDescriptorCollectionProvider.Object);
+		private readonly Mock<IUrlHelper> _mockUrlHelper;
+		private readonly Mock<IActionDescriptorCollectionProvider> _mockActionDescriptorCollectionProvider;
 
-            // act
-            var resourceLink = sut.Create(routeName, routeDictionary);
+		[Theory]
+		[CreateResourceLinkData]
+		[Trait(nameof(IResourceLinkFactory), nameof(IResourceLinkFactory.Create))]
+		public void Create_ValidParameters_ReturnsResourceLink(object data, string routeName, string url, string method)
+		{
+			// arrange
+			ActionDescriptorCollectionProviderArrangements(routeName, method);
+			var routeDictionary = data?.ToRouteDictionary(); // can be null
+			_mockUrlHelper.Setup(x => x.Link(routeName, routeDictionary)).Returns(url);
+			var sut = new ResourceLinkFactory(_mockUrlHelper.Object, _mockActionDescriptorCollectionProvider.Object);
 
-            // assert
-            Assert.IsType<ResourceLink>(resourceLink);
-            Assert.NotNull(resourceLink);
-            Assert.Equal(url, resourceLink.Href);
-            Assert.Equal(routeName, resourceLink.Rel);
-            Assert.Equal(method, resourceLink.Method);
-        }
+			// act
+			var resourceLink = sut.Create(routeName, routeDictionary);
 
-        [Theory]
-        [InlineData("")]
-        [InlineData(null)]
-        [Trait(nameof(IResourceLinkFactory), nameof(IResourceLinkFactory.Create))]
-        [Trait(nameof(IResourceLinkFactory), "Exceptions")]
-        public void Create_WithRouteNameNull_Throws_ArgumentNullException(string rel)
-        {
-            // arrange
-            ActionDescriptorCollectionProviderArrangements(rel);
-            var sut = new ResourceLinkFactory(_mockUrlHelper.Object, _mockActionDescriptorCollectionProvider.Object);
-            const string parameterName = "rel";
+			// assert
+			Assert.IsType<ResourceLink>(resourceLink);
+			Assert.NotNull(resourceLink);
+			Assert.Equal(url, resourceLink.Href);
+			Assert.Equal(routeName, resourceLink.Rel);
+			Assert.Equal(method, resourceLink.Method);
+		}
 
-            // act
-            Action actual = () => sut.Create(rel, It.IsAny<IDictionary<string, object>>());
+		[Theory]
+		[InlineData("")]
+		[InlineData(null)]
+		[Trait(nameof(IResourceLinkFactory), nameof(IResourceLinkFactory.Create))]
+		[Trait(nameof(IResourceLinkFactory), "Exceptions")]
+		public void Create_WithRouteNameNull_Throws_ArgumentNullException(string rel)
+		{
+			// arrange
+			ActionDescriptorCollectionProviderArrangements(rel);
+			var sut = new ResourceLinkFactory(_mockUrlHelper.Object, _mockActionDescriptorCollectionProvider.Object);
+			const string parameterName = "rel";
 
-            // assert
-            Assert.Throws<ArgumentNullException>(parameterName, actual);
-        }
+			// act
+			Action actual = () => sut.Create(rel, It.IsAny<IDictionary<string, object>>());
 
-        [Fact]
-        [Trait(nameof(IResourceLinkFactory), nameof(IResourceLinkFactory.Create))]
-        [Trait(nameof(IResourceLinkFactory), "Exceptions")]
-        public void Create_WithRouteNotFound_Throws_NotSupportedException()
-        {
-            // arrange
-            const string existentRouteName = "exists";
-            const string notExistentRouteName = "notExists";
-            ActionDescriptorCollectionProviderArrangements(existentRouteName);
-            var sut = new ResourceLinkFactory(_mockUrlHelper.Object, _mockActionDescriptorCollectionProvider.Object);
+			// assert
+			Assert.Throws<ArgumentNullException>(parameterName, actual);
+		}
 
-            // act
-            Action actual = () => sut.Create(notExistentRouteName, It.IsAny<IDictionary<string, object>>());
+		private void ActionDescriptorCollectionProviderArrangements(string routeName, string method = "GET")
+		{
+			var actionDescriptors = new List<ActionDescriptor>
+			{
+				new ActionDescriptor
+				{
+					AttributeRouteInfo = new AttributeRouteInfo {Name = routeName},
+					ActionConstraints = new List<IActionConstraintMetadata>
+						{new HttpMethodActionConstraint(new List<string> {method})}
+				}
+			};
+			_mockActionDescriptorCollectionProvider.Setup(x => x.ActionDescriptors)
+			                                       .Returns(new ActionDescriptorCollection(actionDescriptors, 1));
+		}
 
-            // assert
-            Assert.Throws<NotSupportedException>(actual);
-        }
+		[Fact]
+		[Trait(nameof(IResourceLinkFactory), nameof(IResourceLinkFactory.Create))]
+		[Trait(nameof(IResourceLinkFactory), "Exceptions")]
+		public void Create_WithRouteNotFound_Throws_NotSupportedException()
+		{
+			// arrange
+			const string existentRouteName = "exists";
+			const string notExistentRouteName = "notExists";
+			ActionDescriptorCollectionProviderArrangements(existentRouteName);
+			var sut = new ResourceLinkFactory(_mockUrlHelper.Object, _mockActionDescriptorCollectionProvider.Object);
 
-        private void ActionDescriptorCollectionProviderArrangements(string routeName, string method = "GET")
-        {
-            var actionDescriptors = new List<ActionDescriptor>
-            {
-                new ActionDescriptor
-                {
-                    AttributeRouteInfo = new AttributeRouteInfo {Name = routeName},
-                    ActionConstraints = new List<IActionConstraintMetadata>
-                        {new HttpMethodActionConstraint(new List<string>() {method})}
-                }
-            };
-            _mockActionDescriptorCollectionProvider.Setup(x => x.ActionDescriptors)
-                                                   .Returns(new ActionDescriptorCollection(actionDescriptors, 1));
-        }
+			// act
+			Action actual = () => sut.Create(notExistentRouteName, It.IsAny<IDictionary<string, object>>());
 
-        /// <inheritdoc />
-        public void Dispose()
-        {
-            GC.SuppressFinalize(this);
-        }
-    }
+			// assert
+			Assert.Throws<NotSupportedException>(actual);
+		}
+	}
 }

--- a/HateoasNet.Core.Tests/Formatting/FormattingDataAttribute.cs
+++ b/HateoasNet.Core.Tests/Formatting/FormattingDataAttribute.cs
@@ -1,63 +1,63 @@
-using HateoasNet.Resources;
-using HateoasNet.TestingObjects;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using HateoasNet.Resources;
+using HateoasNet.TestingObjects;
 using Xunit.Sdk;
 
 namespace HateoasNet.Core.Tests.Formatting
 {
-    public class FormattingDataAttribute : DataAttribute
-    {
-        public override IEnumerable<object[]> GetData(MethodInfo testMethod)
-        {
-            // Guid and DateTime values shared for serialization test
-            var sharedGuid = Guid.Parse("96685bc4-dcb7-4b22-90cc-ca83baff8186");
-            var sharedDateTime = DateTime.Parse("Fri, 1 May 2020 00:00:00Z");
+	public class FormattingDataAttribute : DataAttribute
+	{
+		public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+		{
+			// Guid and DateTime values shared for serialization test
+			var sharedGuid = Guid.Parse("96685bc4-dcb7-4b22-90cc-ca83baff8186");
+			var sharedDateTime = DateTime.Parse("Fri, 1 May 2020 00:00:00Z");
 
-            // dummies
-            var emptyLink = new ResourceLink("", "", "");
-            var testee = new Testee { Id = sharedGuid, CreatedDate = sharedDateTime };
-            var nestedTestee = new NestedTestee
-            {
-                Id = sharedGuid,
-                CreatedDate = sharedDateTime,
-                Nested = testee,
-                Collection = new List<Testee> { testee }
-            };
-            var genericTestee = new GenericTestee<Testee>
-            {
-                Nested = nestedTestee,
-                Id = sharedGuid,
-                CreatedDate = sharedDateTime,
-                Collection = new List<Testee> { testee, nestedTestee }
-            };
-            var testeeList = new List<Testee> { testee, nestedTestee, genericTestee };
-            var testeePagination = new Pagination<Testee>(testeeList, testeeList.Count, 5);
+			// dummies
+			var emptyLink = new ResourceLink("", "", "");
+			var testee = new Testee {Id = sharedGuid, CreatedDate = sharedDateTime};
+			var nestedTestee = new NestedTestee
+			{
+				Id = sharedGuid,
+				CreatedDate = sharedDateTime,
+				Nested = testee,
+				Collection = new List<Testee> {testee}
+			};
+			var genericTestee = new GenericTestee<Testee>
+			{
+				Nested = nestedTestee,
+				Id = sharedGuid,
+				CreatedDate = sharedDateTime,
+				Collection = new List<Testee> {testee, nestedTestee}
+			};
+			var testeeList = new List<Testee> {testee, nestedTestee, genericTestee};
+			var testeePagination = new Pagination<Testee>(testeeList, testeeList.Count, 5);
 
-            // resources
-            var resources = testeeList.Select(x =>
-            {
-                var resource = new SingleResource(x);
-                resource.Links.Add(emptyLink);
-                return resource;
-            }).ToList();
+			// resources
+			var resources = testeeList.Select(x =>
+			{
+				var resource = new SingleResource(x);
+				resource.Links.Add(emptyLink);
+				return resource;
+			}).ToList();
 
-            var enumerableResource = new EnumerableResource(resources);
-            enumerableResource.Links.Add(emptyLink);
-            var paginationResource = new PaginationResource(resources, resources.Count(), 5, 1);
-            paginationResource.Links.Add(emptyLink);
+			var enumerableResource = new EnumerableResource(resources);
+			enumerableResource.Links.Add(emptyLink);
+			var paginationResource = new PaginationResource(resources, resources.Count(), 5, 1);
+			paginationResource.Links.Add(emptyLink);
 
-            // expectedOutputs
-            var expectedSingleString = File.ReadAllText(Path.Combine("Serialization", "SingleResource.json"));
-            var expectedEnumerableString = File.ReadAllText(Path.Combine("Serialization", "EnumerableResource.json"));
-            var expectedPaginationString = File.ReadAllText(Path.Combine("Serialization", "PaginationResource.json"));
+			// expectedOutputs
+			var expectedSingleString = File.ReadAllText(Path.Combine("Serialization", "SingleResource.json"));
+			var expectedEnumerableString = File.ReadAllText(Path.Combine("Serialization", "EnumerableResource.json"));
+			var expectedPaginationString = File.ReadAllText(Path.Combine("Serialization", "PaginationResource.json"));
 
-            yield return new object[] { testee, resources.First(), expectedSingleString };
-            yield return new object[] { testeeList, enumerableResource, expectedEnumerableString };
-            yield return new object[] { testeePagination, paginationResource, expectedPaginationString };
-        }
-    }
+			yield return new object[] {testee, resources.First(), expectedSingleString};
+			yield return new object[] {testeeList, enumerableResource, expectedEnumerableString};
+			yield return new object[] {testeePagination, paginationResource, expectedPaginationString};
+		}
+	}
 }

--- a/HateoasNet.Core.Tests/Formatting/HateoasFormatterTests.cs
+++ b/HateoasNet.Core.Tests/Formatting/HateoasFormatterTests.cs
@@ -1,83 +1,83 @@
-﻿using HateoasNet.Abstractions;
+﻿using System;
+using System.Collections;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using HateoasNet.Abstractions;
 using HateoasNet.Core.Formatting;
 using HateoasNet.Core.Serialization;
 using HateoasNet.Resources;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Moq;
-using System;
-using System.Collections;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace HateoasNet.Core.Tests.Formatting
 {
-    public class HateoasFormatterTests : IDisposable
-    {
-        [Theory]
-        [FormattingData]
-        [Trait(nameof(HateoasFormatter), nameof(HateoasFormatter.WriteResponseBodyAsync))]
-        public async Task WriteResponseBodyAsync_ValidParameters_WriteExpectedText(
-            object value, Resource resource, string text)
-        {
-            // arrange
-            var type = value.GetType();
-            var mockResourceFactory = GenerateFullResourceFactoryMock(resource, value, type);
-            var sut = new HateoasFormatter(mockResourceFactory.Object, new HateoasSerializer());
-            var expectedContentType = sut.SupportedMediaTypes.Last();
-            var context = GenerateParameterOutputFormatterWriteContext(value, type);
+	public class HateoasFormatterTests : IDisposable
+	{
+		/// <inheritdoc />
+		public void Dispose()
+		{
+			GC.SuppressFinalize(this);
+		}
 
-            // act
-            await sut.WriteResponseBodyAsync(context);
-            mockResourceFactory.Verify();
-            // reset position and read the stream to capture formatted string output
-            context.HttpContext.Response.Body.Seek(0, SeekOrigin.Begin);
-            var actualOutput = await new StreamReader(context.HttpContext.Response.Body).ReadToEndAsync();
-            var actualContentType = context.HttpContext.Response.ContentType;
+		[Theory]
+		[FormattingData]
+		[Trait(nameof(HateoasFormatter), nameof(HateoasFormatter.WriteResponseBodyAsync))]
+		public async Task WriteResponseBodyAsync_ValidParameters_WriteExpectedText(
+			object value, Resource resource, string text)
+		{
+			// arrange
+			var type = value.GetType();
+			var mockResourceFactory = GenerateFullResourceFactoryMock(resource, value, type);
+			var sut = new HateoasFormatter(mockResourceFactory.Object, new HateoasSerializer());
+			var expectedContentType = sut.SupportedMediaTypes.Last();
+			var context = GenerateParameterOutputFormatterWriteContext(value, type);
 
-            // assert
-            Assert.Equal(expectedContentType, actualContentType);
-            Assert.Equal(text, actualOutput);
-        }
+			// act
+			await sut.WriteResponseBodyAsync(context);
+			mockResourceFactory.Verify();
+			// reset position and read the stream to capture formatted string output
+			context.HttpContext.Response.Body.Seek(0, SeekOrigin.Begin);
+			var actualOutput = await new StreamReader(context.HttpContext.Response.Body).ReadToEndAsync();
+			var actualContentType = context.HttpContext.Response.ContentType;
 
-        private Mock<IResourceFactory> GenerateFullResourceFactoryMock(Resource resource, object value, Type type)
-        {
-            var mockResourceFactory = new Mock<IResourceFactory>();
-            switch (value)
-            {
-                case IEnumerable enumerable:
-                    mockResourceFactory.Setup(x => x.Create(enumerable, type))
-                                       .Returns(resource as EnumerableResource)
-                                       .Verifiable("unable to call Create with enumerable.");
-                    break;
-                case IPagination pagination:
-                    mockResourceFactory.Setup(x => x.Create(pagination, type))
-                                       .Returns(resource as PaginationResource)
-                                       .Verifiable("unable to call Create with pagination.");
-                    break;
-                default:
-                    mockResourceFactory.Setup(x => x.Create(value, type))
-                                       .Returns(resource as SingleResource)
-                                       .Verifiable("unable to call Create with object.");
-                    break;
-            }
+			// assert
+			Assert.Equal(expectedContentType, actualContentType);
+			Assert.Equal(text, actualOutput);
+		}
 
-            return mockResourceFactory;
-        }
+		private Mock<IResourceFactory> GenerateFullResourceFactoryMock(Resource resource, object value, Type type)
+		{
+			var mockResourceFactory = new Mock<IResourceFactory>();
+			switch (value)
+			{
+				case IEnumerable enumerable:
+					mockResourceFactory.Setup(x => x.Create(enumerable, type))
+					                   .Returns(resource as EnumerableResource)
+					                   .Verifiable("unable to call Create with enumerable.");
+					break;
+				case IPagination pagination:
+					mockResourceFactory.Setup(x => x.Create(pagination, type))
+					                   .Returns(resource as PaginationResource)
+					                   .Verifiable("unable to call Create with pagination.");
+					break;
+				default:
+					mockResourceFactory.Setup(x => x.Create(value, type))
+					                   .Returns(resource as SingleResource)
+					                   .Verifiable("unable to call Create with object.");
+					break;
+			}
 
-        private OutputFormatterWriteContext GenerateParameterOutputFormatterWriteContext(object value, Type type)
-        {
-            var httpContext = new DefaultHttpContext();
-            httpContext.Response.Body = new MemoryStream();
-            return new OutputFormatterWriteContext(httpContext, (s, e) => new StreamWriter(s, e), type, value);
-        }
+			return mockResourceFactory;
+		}
 
-        /// <inheritdoc />
-        public void Dispose()
-        {
-            GC.SuppressFinalize(this);
-        }
-    }
+		private OutputFormatterWriteContext GenerateParameterOutputFormatterWriteContext(object value, Type type)
+		{
+			var httpContext = new DefaultHttpContext();
+			httpContext.Response.Body = new MemoryStream();
+			return new OutputFormatterWriteContext(httpContext, (s, e) => new StreamWriter(s, e), type, value);
+		}
+	}
 }

--- a/HateoasNet.Core.Tests/Serialization/AddConverterDataAttribute.cs
+++ b/HateoasNet.Core.Tests/Serialization/AddConverterDataAttribute.cs
@@ -1,17 +1,17 @@
-﻿using HateoasNet.Core.Serialization;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
+using HateoasNet.Core.Serialization;
 using Xunit.Sdk;
 
 namespace HateoasNet.Core.Tests.Serialization
 {
-    internal class AddConverterDataAttribute : DataAttribute
-    {
-        /// <inheritdoc />
-        public override IEnumerable<object[]> GetData(MethodInfo testMethod)
-        {
-            yield return new object[] { new GuidConverter() };
-            yield return new object[] { new DateTimeConverter() };
-        }
-    }
+	internal class AddConverterDataAttribute : DataAttribute
+	{
+		/// <inheritdoc />
+		public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+		{
+			yield return new object[] {new GuidConverter()};
+			yield return new object[] {new DateTimeConverter()};
+		}
+	}
 }

--- a/HateoasNet.Core.Tests/Serialization/HateoasSerializerTests.cs
+++ b/HateoasNet.Core.Tests/Serialization/HateoasSerializerTests.cs
@@ -1,100 +1,100 @@
-using HateoasNet.Abstractions;
-using HateoasNet.Core.Serialization;
-using HateoasNet.Resources;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
+using HateoasNet.Abstractions;
+using HateoasNet.Core.Serialization;
+using HateoasNet.Resources;
 using Xunit;
 
 namespace HateoasNet.Core.Tests.Serialization
 {
-    public class HateoasSerializerTests : IDisposable
-    {
-        [Theory]
-        [SerializationData]
-        [Trait(nameof(IHateoasSerializer), nameof(IHateoasSerializer.SerializeResource))]
-        public void SerializeResource_WithValidResource_ReturnsExpectedString(Resource resource, string expectedOutput)
-        {
-            // arrange
-            var sut = new HateoasSerializer();
+	public class HateoasSerializerTests : IDisposable
+	{
+		/// <inheritdoc />
+		public void Dispose()
+		{
+			GC.SuppressFinalize(this);
+		}
 
-            // act
-            var actual = sut.SerializeResource(resource);
+		[Theory]
+		[SerializationData]
+		[Trait(nameof(IHateoasSerializer), nameof(IHateoasSerializer.SerializeResource))]
+		public void SerializeResource_WithValidResource_ReturnsExpectedString(Resource resource, string expectedOutput)
+		{
+			// arrange
+			var sut = new HateoasSerializer();
 
-            // assert
-            Assert.Equal(expectedOutput, actual);
-        }
+			// act
+			var actual = sut.SerializeResource(resource);
 
-        [Fact]
-        [Trait(nameof(IHateoasSerializer), nameof(HateoasSerializer.ResetConverters))]
-        public void ResetConverters_SetConverters_ToEmptyList()
-        {
-            // arrange
-            var sut = new HateoasSerializer();
-            var defaultConverters = new List<JsonConverter> { new GuidConverter(), new DateTimeConverter() };
-            var initialConverters = new List<JsonConverter>(sut.Settings.Converters);
+			// assert
+			Assert.Equal(expectedOutput, actual);
+		}
 
-            // act
-            sut.ResetConverters();
+		[Theory]
+		[AddConverterData]
+		[Trait(nameof(IHateoasSerializer), nameof(HateoasSerializer.AddConverter))]
+		public void AddConverter_WithValidJsonConverter_AddsNewConverter<T>(JsonConverter<T> converter)
+		{
+			// arrange
+			var sut = new HateoasSerializer();
+			sut.ResetConverters();
 
-            // assert
-            Assert.Contains(initialConverters, x => defaultConverters.Any(c => c.GetType() == x.GetType()));
-            Assert.Collection(initialConverters, x => x.CanConvert(typeof(Guid)), x => x.CanConvert(typeof(DateTime)));
-            Assert.Empty(sut.Settings.Converters);
-        }
+			// act
+			sut.AddConverter(converter);
 
-        [Theory]
-        [AddConverterData]
-        [Trait(nameof(IHateoasSerializer), nameof(HateoasSerializer.AddConverter))]
-        public void AddConverter_WithValidJsonConverter_AddsNewConverter<T>(JsonConverter<T> converter)
-        {
-            // arrange
-            var sut = new HateoasSerializer();
-            sut.ResetConverters();
+			// assert
+			Assert.Contains(sut.Settings.Converters, x => x.GetType() == converter.GetType());
+			Assert.Collection(sut.Settings.Converters, x => x.CanConvert(typeof(T)));
+		}
 
-            // act
-            sut.AddConverter(converter);
+		[Fact]
+		[Trait(nameof(IHateoasSerializer), nameof(HateoasSerializer.ResetConverters))]
+		public void ResetConverters_SetConverters_ToEmptyList()
+		{
+			// arrange
+			var sut = new HateoasSerializer();
+			var defaultConverters = new List<JsonConverter> {new GuidConverter(), new DateTimeConverter()};
+			var initialConverters = new List<JsonConverter>(sut.Settings.Converters);
 
-            // assert
-            Assert.Contains(sut.Settings.Converters, x => x.GetType() == converter.GetType());
-            Assert.Collection(sut.Settings.Converters, x => x.CanConvert(typeof(T)));
-        }
+			// act
+			sut.ResetConverters();
 
-        [Fact]
-        [Trait(nameof(IHateoasSerializer), nameof(IHateoasSerializer.SerializeResource))]
-        [Trait(nameof(IHateoasSerializer), "Exceptions")]
-        public void SerializeResource_WithResourceNull_Throws_ArgumentNullException()
-        {
-            // arrange
-            var sut = new HateoasSerializer();
-            const string parameterName = "resource";
+			// assert
+			Assert.Contains(initialConverters, x => defaultConverters.Any(c => c.GetType() == x.GetType()));
+			Assert.Collection(initialConverters, x => x.CanConvert(typeof(Guid)), x => x.CanConvert(typeof(DateTime)));
+			Assert.Empty(sut.Settings.Converters);
+		}
 
-            // act
-            Action actual = () => sut.SerializeResource(null);
+		[Fact]
+		[Trait(nameof(IHateoasSerializer), nameof(IHateoasSerializer.SerializeResource))]
+		[Trait(nameof(IHateoasSerializer), "Exceptions")]
+		public void SerializeResource_WithResourceNull_Throws_ArgumentNullException()
+		{
+			// arrange
+			var sut = new HateoasSerializer();
+			const string parameterName = "resource";
 
-            Assert.Throws<ArgumentNullException>(parameterName, actual);
-        }
+			// act
+			Action actual = () => sut.SerializeResource(null);
 
-        [Fact]
-        [Trait(nameof(IHateoasSerializer), nameof(HateoasSerializer.AddConverter))]
-        [Trait(nameof(IHateoasSerializer), "Exceptions")]
-        public void Throws_ArgumentNullException_FromCalling_AddConverter()
-        {
-            // arrange
-            var sut = new HateoasSerializer();
-            const string parameterName = "converter";
+			Assert.Throws<ArgumentNullException>(parameterName, actual);
+		}
 
-            // act
-            Action actual = () => sut.AddConverter<Guid>(null);
+		[Fact]
+		[Trait(nameof(IHateoasSerializer), nameof(HateoasSerializer.AddConverter))]
+		[Trait(nameof(IHateoasSerializer), "Exceptions")]
+		public void Throws_ArgumentNullException_FromCalling_AddConverter()
+		{
+			// arrange
+			var sut = new HateoasSerializer();
+			const string parameterName = "converter";
 
-            Assert.Throws<ArgumentNullException>(parameterName, actual);
-        }
+			// act
+			Action actual = () => sut.AddConverter<Guid>(null);
 
-        /// <inheritdoc />
-        public void Dispose()
-        {
-            GC.SuppressFinalize(this);
-        }
-    }
+			Assert.Throws<ArgumentNullException>(parameterName, actual);
+		}
+	}
 }

--- a/HateoasNet.Core.Tests/Serialization/SerializationDataAttribute.cs
+++ b/HateoasNet.Core.Tests/Serialization/SerializationDataAttribute.cs
@@ -1,62 +1,62 @@
-using HateoasNet.Resources;
-using HateoasNet.TestingObjects;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using HateoasNet.Resources;
+using HateoasNet.TestingObjects;
 using Xunit.Sdk;
 
 namespace HateoasNet.Core.Tests.Serialization
 {
-    public class SerializationDataAttribute : DataAttribute
-    {
-        public override IEnumerable<object[]> GetData(MethodInfo testMethod)
-        {
-            // Guid and DateTime values shared for serialization test
-            var sharedGuid = Guid.Parse("96685bc4-dcb7-4b22-90cc-ca83baff8186");
-            var sharedDateTime = DateTime.Parse("Fri, 1 May 2020 00:00:00Z");
+	public class SerializationDataAttribute : DataAttribute
+	{
+		public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+		{
+			// Guid and DateTime values shared for serialization test
+			var sharedGuid = Guid.Parse("96685bc4-dcb7-4b22-90cc-ca83baff8186");
+			var sharedDateTime = DateTime.Parse("Fri, 1 May 2020 00:00:00Z");
 
-            // dummies
-            var emptyLink = new ResourceLink("", "", "");
-            var testee = new Testee { Id = sharedGuid, CreatedDate = sharedDateTime };
-            var nestedTestee = new NestedTestee
-            {
-                Id = sharedGuid,
-                CreatedDate = sharedDateTime,
-                Nested = testee,
-                Collection = new List<Testee> { testee }
-            };
-            var genericTestee = new GenericTestee<Testee>
-            {
-                Nested = nestedTestee,
-                Id = sharedGuid,
-                CreatedDate = sharedDateTime,
-                Collection = new List<Testee> { testee, nestedTestee }
-            };
-            var testees = new List<Testee> { testee, nestedTestee, genericTestee };
+			// dummies
+			var emptyLink = new ResourceLink("", "", "");
+			var testee = new Testee {Id = sharedGuid, CreatedDate = sharedDateTime};
+			var nestedTestee = new NestedTestee
+			{
+				Id = sharedGuid,
+				CreatedDate = sharedDateTime,
+				Nested = testee,
+				Collection = new List<Testee> {testee}
+			};
+			var genericTestee = new GenericTestee<Testee>
+			{
+				Nested = nestedTestee,
+				Id = sharedGuid,
+				CreatedDate = sharedDateTime,
+				Collection = new List<Testee> {testee, nestedTestee}
+			};
+			var testees = new List<Testee> {testee, nestedTestee, genericTestee};
 
-            // resources
-            var resources = testees.Select(x =>
-            {
-                var resource = new SingleResource(x);
-                resource.Links.Add(emptyLink);
-                return resource;
-            }).ToList();
+			// resources
+			var resources = testees.Select(x =>
+			{
+				var resource = new SingleResource(x);
+				resource.Links.Add(emptyLink);
+				return resource;
+			}).ToList();
 
-            var enumerableResource = new EnumerableResource(resources);
-            enumerableResource.Links.Add(emptyLink);
-            var paginationResource = new PaginationResource(resources, resources.Count(), 5, 1);
-            paginationResource.Links.Add(emptyLink);
+			var enumerableResource = new EnumerableResource(resources);
+			enumerableResource.Links.Add(emptyLink);
+			var paginationResource = new PaginationResource(resources, resources.Count(), 5, 1);
+			paginationResource.Links.Add(emptyLink);
 
-            // expectedOutputs
-            var expectedSingleString = File.ReadAllText(Path.Combine("Serialization", "SingleResource.json"));
-            var expectedEnumerableString = File.ReadAllText(Path.Combine("Serialization", "EnumerableResource.json"));
-            var expectedPaginationString = File.ReadAllText(Path.Combine("Serialization", "PaginationResource.json"));
+			// expectedOutputs
+			var expectedSingleString = File.ReadAllText(Path.Combine("Serialization", "SingleResource.json"));
+			var expectedEnumerableString = File.ReadAllText(Path.Combine("Serialization", "EnumerableResource.json"));
+			var expectedPaginationString = File.ReadAllText(Path.Combine("Serialization", "PaginationResource.json"));
 
-            yield return new object[] { resources.First(), expectedSingleString };
-            yield return new object[] { enumerableResource, expectedEnumerableString };
-            yield return new object[] { paginationResource, expectedPaginationString };
-        }
-    }
+			yield return new object[] {resources.First(), expectedSingleString};
+			yield return new object[] {enumerableResource, expectedEnumerableString};
+			yield return new object[] {paginationResource, expectedPaginationString};
+		}
+	}
 }

--- a/HateoasNet.Core/DependencyInjection/HateoasExtensions.cs
+++ b/HateoasNet.Core/DependencyInjection/HateoasExtensions.cs
@@ -1,4 +1,5 @@
-﻿using HateoasNet.Abstractions;
+﻿using System;
+using HateoasNet.Abstractions;
 using HateoasNet.Configurations;
 using HateoasNet.Core.Factories;
 using HateoasNet.Core.Formatting;
@@ -7,12 +8,11 @@ using HateoasNet.Factories;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.Extensions.DependencyInjection;
-using System;
 
 namespace HateoasNet.Core.DependencyInjection
 {
-    public static class HateoasExtensions
-    {
+	public static class HateoasExtensions
+	{
         /// <summary>
         ///   Configure Hateoas Resource mapping in .Net Core Web Api and register HateoasNet required services to
         ///   .net core default dependency injection container
@@ -23,19 +23,19 @@ namespace HateoasNet.Core.DependencyInjection
         /// <exception cref="ArgumentNullException"></exception>
         public static IServiceCollection ConfigureHateoas(this IServiceCollection services,
                                                           Func<IHateoasContext, IHateoasContext> hateoasConfiguration)
-        {
-            if (hateoasConfiguration == null) throw new ArgumentNullException(nameof(hateoasConfiguration));
+		{
+			if (hateoasConfiguration == null) throw new ArgumentNullException(nameof(hateoasConfiguration));
 
-            return services
-                   .AddSingleton<IActionContextAccessor, ActionContextAccessor>()
-                   .AddSingleton<IUrlHelperFactory, UrlHelperFactory>()
-                   .AddTransient(x => hateoasConfiguration(new HateoasContext()))
-                   .AddTransient(x => x.GetRequiredService<IUrlHelperFactory>()
-                                       .GetUrlHelper(x.GetRequiredService<IActionContextAccessor>().ActionContext))
-                   .AddTransient<IResourceLinkFactory, ResourceLinkFactory>()
-                   .AddTransient<IResourceFactory, ResourceFactory>()
-                   .AddTransient<IHateoasSerializer, HateoasSerializer>();
-        }
+			return services
+			       .AddSingleton<IActionContextAccessor, ActionContextAccessor>()
+			       .AddSingleton<IUrlHelperFactory, UrlHelperFactory>()
+			       .AddTransient(x => hateoasConfiguration(new HateoasContext()))
+			       .AddTransient(x => x.GetRequiredService<IUrlHelperFactory>()
+			                           .GetUrlHelper(x.GetRequiredService<IActionContextAccessor>().ActionContext))
+			       .AddTransient<IResourceLinkFactory, ResourceLinkFactory>()
+			       .AddTransient<IResourceFactory, ResourceFactory>()
+			       .AddTransient<IHateoasSerializer, HateoasSerializer>();
+		}
 
         /// <summary>
         ///   Add HateoasFormatter to MvcBuilder OutputFormatters
@@ -44,8 +44,8 @@ namespace HateoasNet.Core.DependencyInjection
         /// <returns></returns>
         /// <exception cref="ArgumentNullException"></exception>
         public static IMvcBuilder AddHateoasFormatter(this IMvcBuilder builder)
-        {
-            return builder.AddMvcOptions(o => o.OutputFormatters.Add(new HateoasFormatter()));
-        }
-    }
+		{
+			return builder.AddMvcOptions(o => o.OutputFormatters.Add(new HateoasFormatter()));
+		}
+	}
 }

--- a/HateoasNet.Core/Factories/ResourceLinkFactory.cs
+++ b/HateoasNet.Core/Factories/ResourceLinkFactory.cs
@@ -1,45 +1,43 @@
-﻿using HateoasNet.Abstractions;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using HateoasNet.Abstractions;
 using HateoasNet.Resources;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.ActionConstraints;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace HateoasNet.Core.Factories
 {
-    /// <inheritdoc cref="IResourceLinkFactory" />
-    public sealed class ResourceLinkFactory : IResourceLinkFactory
-    {
-        private readonly IReadOnlyList<ActionDescriptor> _actionDescriptors;
-        private readonly IUrlHelper _urlHelper;
+	/// <inheritdoc cref="IResourceLinkFactory" />
+	public sealed class ResourceLinkFactory : IResourceLinkFactory
+	{
+		private readonly IReadOnlyList<ActionDescriptor> _actionDescriptors;
+		private readonly IUrlHelper _urlHelper;
 
-        public ResourceLinkFactory(IUrlHelper urlHelper, IActionDescriptorCollectionProvider actionDescriptorsProvider)
-        {
-            _urlHelper = urlHelper;
-            _actionDescriptors = actionDescriptorsProvider.ActionDescriptors.Items;
-        }
+		public ResourceLinkFactory(IUrlHelper urlHelper, IActionDescriptorCollectionProvider actionDescriptorsProvider)
+		{
+			_urlHelper = urlHelper;
+			_actionDescriptors = actionDescriptorsProvider.ActionDescriptors.Items;
+		}
 
-        public ResourceLink Create(string rel, IDictionary<string, object> routeValues)
-        {
-            if (string.IsNullOrWhiteSpace(rel)) throw new ArgumentNullException(nameof(rel));
-            if (!TryGetActionDescriptorByRouteName(rel, out var actionDescriptor))
-            {
-                throw new NotSupportedException($"Unable to find route '{rel}' and respective {nameof(ActionDescriptor)}");
-            }
+		public ResourceLink Create(string rel, IDictionary<string, object> routeValues)
+		{
+			if (string.IsNullOrWhiteSpace(rel)) throw new ArgumentNullException(nameof(rel));
+			if (!TryGetActionDescriptorByRouteName(rel, out var actionDescriptor))
+				throw new NotSupportedException($"Unable to find route '{rel}' and respective {nameof(ActionDescriptor)}");
 
-            var href = _urlHelper.Link(rel, routeValues);
-            var method = actionDescriptor.ActionConstraints.OfType<HttpMethodActionConstraint>().First().HttpMethods.First();
-            return new ResourceLink(rel, href, method);
-        }
+			var href = _urlHelper.Link(rel, routeValues);
+			var method = actionDescriptor.ActionConstraints.OfType<HttpMethodActionConstraint>().First().HttpMethods.First();
+			return new ResourceLink(rel, href, method);
+		}
 
-        private bool TryGetActionDescriptorByRouteName(string routeName, out ActionDescriptor descriptor)
-        {
-            descriptor = _actionDescriptors.SingleOrDefault(x => x.AttributeRouteInfo.Name == routeName);
+		private bool TryGetActionDescriptorByRouteName(string routeName, out ActionDescriptor descriptor)
+		{
+			descriptor = _actionDescriptors.SingleOrDefault(x => x.AttributeRouteInfo.Name == routeName);
 
-            return descriptor != null;
-        }
-    }
+			return descriptor != null;
+		}
+	}
 }

--- a/HateoasNet.Core/Formatting/HateoasFormatter.cs
+++ b/HateoasNet.Core/Formatting/HateoasFormatter.cs
@@ -1,64 +1,64 @@
-﻿using HateoasNet.Abstractions;
+﻿using System.Collections;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using HateoasNet.Abstractions;
 using HateoasNet.Resources;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Extensions.DependencyInjection;
-using System.Collections;
-using System.Linq;
-using System.Text.Json;
-using System.Threading.Tasks;
 
 namespace HateoasNet.Core.Formatting
 {
-    /// <inheritdoc cref="OutputFormatter" />
-    public class HateoasFormatter : OutputFormatter
-    {
-        private IHateoasSerializer _hateoasSerializer;
-        private IResourceFactory _resourceFactory;
+	/// <inheritdoc cref="OutputFormatter" />
+	public class HateoasFormatter : OutputFormatter
+	{
+		private IHateoasSerializer _hateoasSerializer;
+		private IResourceFactory _resourceFactory;
 
         /// <summary>
-        /// 	Constructor with dependencies injected for testing purposes.
+        ///   Constructor with dependencies injected for testing purposes.
         /// </summary>
         public HateoasFormatter(IResourceFactory resourceFactory, IHateoasSerializer hateoasSerializer) : this()
-        {
-            _resourceFactory = resourceFactory;
-            _hateoasSerializer = hateoasSerializer;
-        }
+		{
+			_resourceFactory = resourceFactory;
+			_hateoasSerializer = hateoasSerializer;
+		}
 
         /// <summary>
-        /// 	Parameterless Constructor, used when getting dependencies within <see cref="WriteResponseBodyAsync" />
-        ///		implementation through <see cref="HttpContext.RequestServices"/>.
+        ///   Parameterless Constructor, used when getting dependencies within <see cref="WriteResponseBodyAsync" />
+        ///   implementation through <see cref="HttpContext.RequestServices" />.
         /// </summary>
         public HateoasFormatter()
-        {
-            SupportedMediaTypes.Add("application/json");
-            SupportedMediaTypes.Add("application/json+hateoas");
-        }
+		{
+			SupportedMediaTypes.Add("application/json");
+			SupportedMediaTypes.Add("application/json+hateoas");
+		}
 
-        public override async Task WriteResponseBodyAsync(OutputFormatterWriteContext context)
-        {
-            if (context.Object is SerializableError error)
-            {
-                var errorOutput = JsonSerializer.Serialize(error);
-                context.HttpContext.Response.ContentType = SupportedMediaTypes.First();
-                await context.HttpContext.Response.WriteAsync(errorOutput);
-                return;
-            }
+		public override async Task WriteResponseBodyAsync(OutputFormatterWriteContext context)
+		{
+			if (context.Object is SerializableError error)
+			{
+				var errorOutput = JsonSerializer.Serialize(error);
+				context.HttpContext.Response.ContentType = SupportedMediaTypes.First();
+				await context.HttpContext.Response.WriteAsync(errorOutput);
+				return;
+			}
 
-            _resourceFactory ??= context.HttpContext.RequestServices.GetRequiredService<IResourceFactory>();
-            _hateoasSerializer ??= context.HttpContext.RequestServices.GetRequiredService<IHateoasSerializer>();
+			_resourceFactory ??= context.HttpContext.RequestServices.GetRequiredService<IResourceFactory>();
+			_hateoasSerializer ??= context.HttpContext.RequestServices.GetRequiredService<IHateoasSerializer>();
 
-            Resource resource = context.Object switch
-            {
-                IPagination pagination => _resourceFactory.Create(pagination, context.ObjectType),
-                IEnumerable enumerable => _resourceFactory.Create(enumerable, context.ObjectType),
-                _ => _resourceFactory.Create(context.Object, context.ObjectType)
-            };
-            var formattedResponse = _hateoasSerializer.SerializeResource(resource);
+			Resource resource = context.Object switch
+			{
+				IPagination pagination => _resourceFactory.Create(pagination, context.ObjectType),
+				IEnumerable enumerable => _resourceFactory.Create(enumerable, context.ObjectType),
+				_ => _resourceFactory.Create(context.Object, context.ObjectType)
+			};
+			var formattedResponse = _hateoasSerializer.SerializeResource(resource);
 
-            context.HttpContext.Response.ContentType = SupportedMediaTypes.Last();
-            await context.HttpContext.Response.WriteAsync(formattedResponse);
-        }
-    }
+			context.HttpContext.Response.ContentType = SupportedMediaTypes.Last();
+			await context.HttpContext.Response.WriteAsync(formattedResponse);
+		}
+	}
 }

--- a/HateoasNet.Core/HateoasNet.Core.csproj
+++ b/HateoasNet.Core/HateoasNet.Core.csproj
@@ -3,16 +3,17 @@
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <LangVersion>8.0</LangVersion>
-        <PackageVersion>1.0.0-alpha</PackageVersion>
         <Title>HateoasNet.Core</Title>
+        <Version>$(Version)</Version>
+        <VersionSuffix>$(VersionSuffix)</VersionSuffix>
         <Authors>icarotorres</Authors>
+        <PackageSummary>.Net Core 3.1 Library for ease Web Api output formatting Json responses with HATEOAS.</PackageSummary>
         <Description>.Net Core 3.1 Library for ease Web Api output formatting Json responses with HATEOAS.</Description>
         <PackageProjectUrl>https://github.com/IcaroTorres/HateoasNet/tree/master/HateoasNet.Core</PackageProjectUrl>
         <PackageLicense>https://github.com/IcaroTorres/HateoasNet/blob/master/LICENSE</PackageLicense>
         <RepositoryUrl>https://github.com/icarotorres/HateoasNet.git</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageTags>json, hateoas, api-rest, hateoas-response, hateoasnet-core</PackageTags>
-        <Version>1.0.0-alpha</Version>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageTypes>
           <PackageType name="Dependency" />

--- a/HateoasNet.Core/Serialization/DateTimeConverter.cs
+++ b/HateoasNet.Core/Serialization/DateTimeConverter.cs
@@ -7,9 +7,18 @@ namespace HateoasNet.Core.Serialization
 {
     public class DateTimeConverter : JsonConverter<DateTime>
     {
+        private readonly string _dateTimeReadFormat;
+        private readonly CultureInfo _cultureInfo;
+
+        public DateTimeConverter(string dateTimeReadFormat = null, CultureInfo cultureInfo = null)
+        {
+            _dateTimeReadFormat = string.IsNullOrWhiteSpace(dateTimeReadFormat) ? "dd/MM/yyyy" : dateTimeReadFormat;
+            _cultureInfo = cultureInfo ?? CultureInfo.InvariantCulture;
+        }
+
         public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return DateTime.ParseExact(reader.GetString(), "dd/MM/yyyy", CultureInfo.InvariantCulture);
+            return DateTime.ParseExact(reader.GetString(), _dateTimeReadFormat, _cultureInfo);
         }
 
         public override void Write(Utf8JsonWriter writer, DateTime date, JsonSerializerOptions options)

--- a/HateoasNet.Core/Serialization/DateTimeConverter.cs
+++ b/HateoasNet.Core/Serialization/DateTimeConverter.cs
@@ -5,25 +5,25 @@ using System.Text.Json.Serialization;
 
 namespace HateoasNet.Core.Serialization
 {
-    public class DateTimeConverter : JsonConverter<DateTime>
-    {
-        private readonly string _dateTimeReadFormat;
-        private readonly CultureInfo _cultureInfo;
+	public class DateTimeConverter : JsonConverter<DateTime>
+	{
+		private readonly CultureInfo _cultureInfo;
+		private readonly string _dateTimeReadFormat;
 
-        public DateTimeConverter(string dateTimeReadFormat = null, CultureInfo cultureInfo = null)
-        {
-            _dateTimeReadFormat = string.IsNullOrWhiteSpace(dateTimeReadFormat) ? "dd/MM/yyyy" : dateTimeReadFormat;
-            _cultureInfo = cultureInfo ?? CultureInfo.InvariantCulture;
-        }
+		public DateTimeConverter(string dateTimeReadFormat = null, CultureInfo cultureInfo = null)
+		{
+			_dateTimeReadFormat = string.IsNullOrWhiteSpace(dateTimeReadFormat) ? "dd/MM/yyyy" : dateTimeReadFormat;
+			_cultureInfo = cultureInfo ?? CultureInfo.InvariantCulture;
+		}
 
-        public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            return DateTime.ParseExact(reader.GetString(), _dateTimeReadFormat, _cultureInfo);
-        }
+		public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			return DateTime.ParseExact(reader.GetString(), _dateTimeReadFormat, _cultureInfo);
+		}
 
-        public override void Write(Utf8JsonWriter writer, DateTime date, JsonSerializerOptions options)
-        {
-            writer.WriteStringValue(date.ToUniversalTime());
-        }
-    }
+		public override void Write(Utf8JsonWriter writer, DateTime date, JsonSerializerOptions options)
+		{
+			writer.WriteStringValue(date.ToUniversalTime());
+		}
+	}
 }

--- a/HateoasNet.Core/Serialization/GuidConverter.cs
+++ b/HateoasNet.Core/Serialization/GuidConverter.cs
@@ -4,16 +4,16 @@ using System.Text.Json.Serialization;
 
 namespace HateoasNet.Core.Serialization
 {
-    public class GuidConverter : JsonConverter<Guid>
-    {
-        public override Guid Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            return Guid.Parse(reader.GetString());
-        }
+	public class GuidConverter : JsonConverter<Guid>
+	{
+		public override Guid Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			return Guid.Parse(reader.GetString());
+		}
 
-        public override void Write(Utf8JsonWriter writer, Guid guidValue, JsonSerializerOptions options)
-        {
-            writer.WriteStringValue(guidValue.ToString());
-        }
-    }
+		public override void Write(Utf8JsonWriter writer, Guid guidValue, JsonSerializerOptions options)
+		{
+			writer.WriteStringValue(guidValue.ToString());
+		}
+	}
 }

--- a/HateoasNet.Core/Serialization/HateoasSerializer.cs
+++ b/HateoasNet.Core/Serialization/HateoasSerializer.cs
@@ -1,57 +1,58 @@
-﻿using HateoasNet.Abstractions;
-using HateoasNet.Resources;
-using System;
+﻿using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using HateoasNet.Abstractions;
+using HateoasNet.Resources;
 
 namespace HateoasNet.Core.Serialization
 {
-    /// <inheritdoc cref="IHateoasSerializer" />
-    public class HateoasSerializer : IHateoasSerializer
-    {
+	/// <inheritdoc cref="IHateoasSerializer" />
+	public class HateoasSerializer : IHateoasSerializer
+	{
+		internal readonly JsonSerializerOptions Settings;
+
         /// <summary>
-        ///   Constructor accepting an optional <see cref="JsonSerializerOptions"/> as <paramref name="settings" />.
+        ///   Constructor accepting an optional <see cref="JsonSerializerOptions" /> as <paramref name="settings" />.
         /// </summary>
         /// <param name="settings">Optional settings for custom output serialization.</param>
         public HateoasSerializer(JsonSerializerOptions settings = null)
-        {
-            Settings = settings ?? new JsonSerializerOptions
-            {
-                IgnoreNullValues = true,
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            };
-            Settings.Converters.Add(new GuidConverter());
-            Settings.Converters.Add(new DateTimeConverter());
-        }
-        internal readonly JsonSerializerOptions Settings;
+		{
+			Settings = settings ?? new JsonSerializerOptions
+			{
+				IgnoreNullValues = true,
+				PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+			};
+			Settings.Converters.Add(new GuidConverter());
+			Settings.Converters.Add(new DateTimeConverter());
+		}
 
-        public string SerializeResource(Resource resource)
-        {
-            if (resource == null) throw new ArgumentNullException(nameof(resource));
+		public string SerializeResource(Resource resource)
+		{
+			if (resource == null) throw new ArgumentNullException(nameof(resource));
 
-            return JsonSerializer.Serialize(resource, resource.GetType(), Settings);
-        }
+			return JsonSerializer.Serialize(resource, resource.GetType(), Settings);
+		}
 
         /// <summary>
         ///   Adds a custom <see cref="JsonConverter{T}" /> to the configured collection of converters.
         /// </summary>
-        /// <returns>Current <see cref="HateoasSerializer"/> instance.</returns>
+        /// <returns>Current <see cref="HateoasSerializer" /> instance.</returns>
         public HateoasSerializer AddConverter<T>(JsonConverter<T> converter)
-        {
-            if (converter == null) throw new ArgumentNullException(nameof(converter));
+		{
+			if (converter == null) throw new ArgumentNullException(nameof(converter));
 
-            Settings.Converters.Add(converter);
-            return this;
-        }
+			Settings.Converters.Add(converter);
+			return this;
+		}
 
         /// <summary>
         ///   Clear the configured collection of JsonConverters.
         /// </summary>
-        /// <returns>Current <see cref="HateoasSerializer"/> instance.</returns>
+        /// <returns>Current <see cref="HateoasSerializer" /> instance.</returns>
         public HateoasSerializer ResetConverters()
-        {
-            Settings.Converters.Clear();
-            return this;
-        }
-    }
+		{
+			Settings.Converters.Clear();
+			return this;
+		}
+	}
 }

--- a/HateoasNet.Framework.Sample/App_Start/FormattersConfig.cs
+++ b/HateoasNet.Framework.Sample/App_Start/FormattersConfig.cs
@@ -1,17 +1,17 @@
-﻿using HateoasNet.Framework.Formatting;
-using System.Web.Http;
+﻿using System.Web.Http;
+using HateoasNet.Framework.Formatting;
 
 namespace HateoasNet.Framework.Sample
 {
-    public static class FormattersConfig
-    {
-        public static void RegisterFormatters(HttpConfiguration config)
-        {
-            // set hateoas formatter using configured IoC container
-            var hateoasFormatter =
-                config.DependencyResolver.GetService(typeof(HateoasMediaTypeFormatter)) as HateoasMediaTypeFormatter;
+	public static class FormattersConfig
+	{
+		public static void RegisterFormatters(HttpConfiguration config)
+		{
+			// set hateoas formatter using configured IoC container
+			var hateoasFormatter =
+				config.DependencyResolver.GetService(typeof(HateoasMediaTypeFormatter)) as HateoasMediaTypeFormatter;
 
-            config.Formatters.Add(hateoasFormatter);
-        }
-    }
+			config.Formatters.Add(hateoasFormatter);
+		}
+	}
 }

--- a/HateoasNet.Framework.Sample/App_Start/HateoasConfig.cs
+++ b/HateoasNet.Framework.Sample/App_Start/HateoasConfig.cs
@@ -1,14 +1,14 @@
-﻿using HateoasNet.Abstractions;
+﻿using System;
+using HateoasNet.Abstractions;
 using HateoasNet.Framework.DependencyInjection;
-using System;
 
 namespace HateoasNet.Framework.Sample
 {
-    public static class HateoasConfig
-    {
-        public static IHateoasContext ConfigureFromAssembly(Type type)
-        {
-            return HateoasExtensions.ConfigureHateoas(context => context.ConfigureFromAssembly(type.Assembly));
-        }
-    }
+	public static class HateoasConfig
+	{
+		public static IHateoasContext ConfigureFromAssembly(Type type)
+		{
+			return HateoasExtensions.ConfigureHateoas(context => context.ConfigureFromAssembly(type.Assembly));
+		}
+	}
 }

--- a/HateoasNet.Framework.Sample/App_Start/RouteConfig.cs
+++ b/HateoasNet.Framework.Sample/App_Start/RouteConfig.cs
@@ -2,12 +2,12 @@
 
 namespace HateoasNet.Framework.Sample
 {
-    public static class RouteConfig
-    {
-        public static void RegisterRoutes(HttpConfiguration config)
-        {
-            // register routes
-            config.MapHttpAttributeRoutes();
-        }
-    }
+	public static class RouteConfig
+	{
+		public static void RegisterRoutes(HttpConfiguration config)
+		{
+			// register routes
+			config.MapHttpAttributeRoutes();
+		}
+	}
 }

--- a/HateoasNet.Framework.Sample/App_Start/UnityConfig.cs
+++ b/HateoasNet.Framework.Sample/App_Start/UnityConfig.cs
@@ -1,3 +1,4 @@
+using System;
 using HateoasNet.Abstractions;
 using HateoasNet.Factories;
 using HateoasNet.Framework.Factories;
@@ -5,7 +6,6 @@ using HateoasNet.Framework.Formatting;
 using HateoasNet.Framework.Sample.HateoasConfigurations;
 using HateoasNet.Framework.Sample.JsonData;
 using HateoasNet.Framework.Serialization;
-using System;
 using Unity;
 
 namespace HateoasNet.Framework.Sample
@@ -14,19 +14,22 @@ namespace HateoasNet.Framework.Sample
     ///   Specifies the Unity configuration for the main Container.
     /// </summary>
     public static class UnityConfig
-    {
-        private static readonly Lazy<IUnityContainer> Container =
-            new Lazy<IUnityContainer>(() =>
-            {
-                var container = new UnityContainer();
-                RegisterTypes(container);
-                return container;
-            });
+	{
+		private static readonly Lazy<IUnityContainer> Container =
+			new Lazy<IUnityContainer>(() =>
+			{
+				var container = new UnityContainer();
+				RegisterTypes(container);
+				return container;
+			});
 
         /// <summary>
         ///   Configured Unity GetContainer.
         /// </summary>
-        public static IUnityContainer GetContainer() => Container.Value;
+        public static IUnityContainer GetContainer()
+		{
+			return Container.Value;
+		}
 
         /// <summary>
         ///   Registers the type mappings with the Unity Container.
@@ -35,14 +38,14 @@ namespace HateoasNet.Framework.Sample
         /// <remarks>
         /// </remarks>
         public static void RegisterTypes(IUnityContainer container)
-        {
-            container
-                .RegisterFactory<IHateoasContext>(f => HateoasConfig.ConfigureFromAssembly(typeof(GuildHateoasResource)))
-                .RegisterFactory<IResourceLinkFactory>(f => new ResourceLinkFactory())
-                .RegisterType<IHateoasSerializer, HateoasSerializer>()
-                .RegisterType<IResourceFactory, ResourceFactory>()
-                .RegisterType<HateoasMediaTypeFormatter>()
-                .RegisterType<Seeder>();
-        }
-    }
+		{
+			container
+				.RegisterFactory<IHateoasContext>(f => HateoasConfig.ConfigureFromAssembly(typeof(GuildHateoasResource)))
+				.RegisterFactory<IResourceLinkFactory>(f => new ResourceLinkFactory())
+				.RegisterType<IHateoasSerializer, HateoasSerializer>()
+				.RegisterType<IResourceFactory, ResourceFactory>()
+				.RegisterType<HateoasMediaTypeFormatter>()
+				.RegisterType<Seeder>();
+		}
+	}
 }

--- a/HateoasNet.Framework.Sample/App_Start/UnityConfig.cs
+++ b/HateoasNet.Framework.Sample/App_Start/UnityConfig.cs
@@ -11,11 +11,11 @@ using Unity;
 namespace HateoasNet.Framework.Sample
 {
     /// <summary>
-    ///   Specifies the Unity configuration for the main _container.
+    ///   Specifies the Unity configuration for the main Container.
     /// </summary>
     public static class UnityConfig
     {
-        private static readonly Lazy<IUnityContainer> _container =
+        private static readonly Lazy<IUnityContainer> Container =
             new Lazy<IUnityContainer>(() =>
             {
                 var container = new UnityContainer();
@@ -24,14 +24,14 @@ namespace HateoasNet.Framework.Sample
             });
 
         /// <summary>
-        ///   Configured Unity Container.
+        ///   Configured Unity GetContainer.
         /// </summary>
-        public static IUnityContainer Container => _container.Value;
+        public static IUnityContainer GetContainer() => Container.Value;
 
         /// <summary>
-        ///   Registers the type mappings with the Unity _container.
+        ///   Registers the type mappings with the Unity Container.
         /// </summary>
-        /// <param name="container">The unity _container to configure.</param>
+        /// <param name="container">The unity Container to configure.</param>
         /// <remarks>
         /// </remarks>
         public static void RegisterTypes(IUnityContainer container)

--- a/HateoasNet.Framework.Sample/App_Start/UnityWebApiActivator.cs
+++ b/HateoasNet.Framework.Sample/App_Start/UnityWebApiActivator.cs
@@ -18,7 +18,7 @@ namespace HateoasNet.Framework.Sample
         /// </summary>
         public static void Start()
         {
-            var resolver = new UnityHierarchicalDependencyResolver(UnityConfig.Container);
+            var resolver = new UnityHierarchicalDependencyResolver(UnityConfig.GetContainer());
 
             GlobalConfiguration.Configuration.DependencyResolver = resolver;
         }
@@ -28,7 +28,7 @@ namespace HateoasNet.Framework.Sample
         /// </summary>
         public static void Shutdown()
         {
-            UnityConfig.Container.Dispose();
+            UnityConfig.GetContainer().Dispose();
         }
     }
 }

--- a/HateoasNet.Framework.Sample/App_Start/UnityWebApiActivator.cs
+++ b/HateoasNet.Framework.Sample/App_Start/UnityWebApiActivator.cs
@@ -1,5 +1,5 @@
-using HateoasNet.Framework.Sample;
 using System.Web.Http;
+using HateoasNet.Framework.Sample;
 using Unity.AspNet.WebApi;
 using WebActivatorEx;
 
@@ -12,23 +12,23 @@ namespace HateoasNet.Framework.Sample
     ///   Provides the bootstrapping for integrating Unity with WebApi when it is hosted in ASP.NET.
     /// </summary>
     public static class UnityWebApiActivator
-    {
+	{
         /// <summary>
         ///   Integrates Unity when the application starts.
         /// </summary>
         public static void Start()
-        {
-            var resolver = new UnityHierarchicalDependencyResolver(UnityConfig.GetContainer());
+		{
+			var resolver = new UnityHierarchicalDependencyResolver(UnityConfig.GetContainer());
 
-            GlobalConfiguration.Configuration.DependencyResolver = resolver;
-        }
+			GlobalConfiguration.Configuration.DependencyResolver = resolver;
+		}
 
         /// <summary>
         ///   Disposes the Unity container when the application is shut down.
         /// </summary>
         public static void Shutdown()
-        {
-            UnityConfig.GetContainer().Dispose();
-        }
-    }
+		{
+			UnityConfig.GetContainer().Dispose();
+		}
+	}
 }

--- a/HateoasNet.Framework.Sample/Controllers/GuildsController.cs
+++ b/HateoasNet.Framework.Sample/Controllers/GuildsController.cs
@@ -1,49 +1,49 @@
-﻿using HateoasNet.Framework.Sample.JsonData;
-using HateoasNet.Framework.Sample.Models;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web.Http;
+using HateoasNet.Framework.Sample.JsonData;
+using HateoasNet.Framework.Sample.Models;
 
 namespace HateoasNet.Framework.Sample.Controllers
 {
-    [RoutePrefix("some-prefix/guilds")]
-    public class GuildsController : ApiController
-    {
-        private readonly List<Guild> _guilds;
+	[RoutePrefix("some-prefix/guilds")]
+	public class GuildsController : ApiController
+	{
+		private readonly List<Guild> _guilds;
 
-        public GuildsController(Seeder seeder)
-        {
-            _guilds = seeder.Seed<Guild>();
-        }
+		public GuildsController(Seeder seeder)
+		{
+			_guilds = seeder.Seed<Guild>();
+		}
 
-        [HttpGet]
-        [Route("{id:Guid}", Name = "get-guild")]
-        public IHttpActionResult Get(Guid id)
-        {
-            var guild = _guilds.SingleOrDefault(i => i.Id == id);
-            return guild != null ? Ok(guild) : NotFound() as IHttpActionResult;
-        }
+		[HttpGet]
+		[Route("{id:Guid}", Name = "get-guild")]
+		public IHttpActionResult Get(Guid id)
+		{
+			var guild = _guilds.SingleOrDefault(i => i.Id == id);
+			return guild != null ? Ok(guild) : NotFound() as IHttpActionResult;
+		}
 
-        [HttpGet]
-        [Route(Name = "get-guilds")]
-        public IHttpActionResult Get()
-        {
-            return Ok(_guilds);
-        }
+		[HttpGet]
+		[Route(Name = "get-guilds")]
+		public IHttpActionResult Get()
+		{
+			return Ok(_guilds);
+		}
 
-        [HttpPost]
-        [Route(Name = "create-guild")]
-        public IHttpActionResult Post([FromBody] Guild guild)
-        {
-            return CreatedAtRoute("get-guild", new { id = guild.Id }, guild);
-        }
+		[HttpPost]
+		[Route(Name = "create-guild")]
+		public IHttpActionResult Post([FromBody] Guild guild)
+		{
+			return CreatedAtRoute("get-guild", new {id = guild.Id}, guild);
+		}
 
-        [HttpPut]
-        [Route("{id:Guid}", Name = "update-guild")]
-        public IHttpActionResult Put([FromBody] Guild guild)
-        {
-            return Ok(guild);
-        }
-    }
+		[HttpPut]
+		[Route("{id:Guid}", Name = "update-guild")]
+		public IHttpActionResult Put([FromBody] Guild guild)
+		{
+			return Ok(guild);
+		}
+	}
 }

--- a/HateoasNet.Framework.Sample/Controllers/InvitesController.cs
+++ b/HateoasNet.Framework.Sample/Controllers/InvitesController.cs
@@ -1,73 +1,73 @@
-﻿using HateoasNet.Framework.Sample.JsonData;
-using HateoasNet.Framework.Sample.Models;
-using HateoasNet.Resources;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web.Http;
+using HateoasNet.Framework.Sample.JsonData;
+using HateoasNet.Framework.Sample.Models;
+using HateoasNet.Resources;
 
 namespace HateoasNet.Framework.Sample.Controllers
 {
-    [RoutePrefix("some-other-prefix/invites")]
-    public class InvitesController : ApiController
-    {
-        private readonly List<Invite> _invites;
+	[RoutePrefix("some-other-prefix/invites")]
+	public class InvitesController : ApiController
+	{
+		private readonly List<Invite> _invites;
 
-        public InvitesController(Seeder seeder)
-        {
-            _invites = seeder.Seed<Invite>();
-        }
+		public InvitesController(Seeder seeder)
+		{
+			_invites = seeder.Seed<Invite>();
+		}
 
-        [HttpGet]
-        [Route("{id:Guid}", Name = "get-invite")]
-        public IHttpActionResult Get(Guid id)
-        {
-            var invite = _invites.SingleOrDefault(i => i.Id == id);
-            return invite != null ? Ok(invite) : NotFound() as IHttpActionResult;
-        }
+		[HttpGet]
+		[Route("{id:Guid}", Name = "get-invite")]
+		public IHttpActionResult Get(Guid id)
+		{
+			var invite = _invites.SingleOrDefault(i => i.Id == id);
+			return invite != null ? Ok(invite) : NotFound() as IHttpActionResult;
+		}
 
-        [HttpGet]
-        [Route(Name = "get-invites")]
-        public IHttpActionResult Get(int pageSize = 5)
-        {
-            return Ok(new Pagination<Invite>(_invites.Take(pageSize), _invites.Count, pageSize));
-        }
+		[HttpGet]
+		[Route(Name = "get-invites")]
+		public IHttpActionResult Get(int pageSize = 5)
+		{
+			return Ok(new Pagination<Invite>(_invites.Take(pageSize), _invites.Count, pageSize));
+		}
 
-        [HttpPost]
-        [Route(Name = "invite-member")]
-        public IHttpActionResult Post([FromBody] Invite invite)
-        {
-            return CreatedAtRoute("get-invite", new { id = invite.Id }, invite);
-        }
+		[HttpPost]
+		[Route(Name = "invite-member")]
+		public IHttpActionResult Post([FromBody] Invite invite)
+		{
+			return CreatedAtRoute("get-invite", new {id = invite.Id}, invite);
+		}
 
-        [HttpPatch]
-        [Route("{id}/accept", Name = "accept-invite")]
-        public IHttpActionResult Accept(Guid id)
-        {
-            var invite = _invites.SingleOrDefault(i => i.Id == id);
-            if (invite == null) return NotFound();
-            invite.Status = InviteStatuses.Accepted;
-            return Ok(invite);
-        }
+		[HttpPatch]
+		[Route("{id}/accept", Name = "accept-invite")]
+		public IHttpActionResult Accept(Guid id)
+		{
+			var invite = _invites.SingleOrDefault(i => i.Id == id);
+			if (invite == null) return NotFound();
+			invite.Status = InviteStatuses.Accepted;
+			return Ok(invite);
+		}
 
-        [HttpPatch]
-        [Route("{id}/decline", Name = "decline-invite")]
-        public IHttpActionResult Decline(Guid id)
-        {
-            var invite = _invites.SingleOrDefault(i => i.Id == id);
-            if (invite == null) return NotFound();
-            invite.Status = InviteStatuses.Declined;
-            return Ok(invite);
-        }
+		[HttpPatch]
+		[Route("{id}/decline", Name = "decline-invite")]
+		public IHttpActionResult Decline(Guid id)
+		{
+			var invite = _invites.SingleOrDefault(i => i.Id == id);
+			if (invite == null) return NotFound();
+			invite.Status = InviteStatuses.Declined;
+			return Ok(invite);
+		}
 
-        [HttpPatch]
-        [Route("{id}/cancel", Name = "cancel-invite")]
-        public IHttpActionResult Cancel(Guid id)
-        {
-            var invite = _invites.SingleOrDefault(i => i.Id == id);
-            if (invite == null) return NotFound();
-            invite.Status = InviteStatuses.Canceled;
-            return Ok(invite);
-        }
-    }
+		[HttpPatch]
+		[Route("{id}/cancel", Name = "cancel-invite")]
+		public IHttpActionResult Cancel(Guid id)
+		{
+			var invite = _invites.SingleOrDefault(i => i.Id == id);
+			if (invite == null) return NotFound();
+			invite.Status = InviteStatuses.Canceled;
+			return Ok(invite);
+		}
+	}
 }

--- a/HateoasNet.Framework.Sample/Controllers/MembersController.cs
+++ b/HateoasNet.Framework.Sample/Controllers/MembersController.cs
@@ -1,81 +1,81 @@
-﻿using HateoasNet.Framework.Sample.JsonData;
-using HateoasNet.Framework.Sample.Models;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web.Http;
+using HateoasNet.Framework.Sample.JsonData;
+using HateoasNet.Framework.Sample.Models;
 
 namespace HateoasNet.Framework.Sample.Controllers
 {
-    [RoutePrefix("members")]
-    public class MembersController : ApiController
-    {
-        private readonly List<Member> _members;
+	[RoutePrefix("members")]
+	public class MembersController : ApiController
+	{
+		private readonly List<Member> _members;
 
-        public MembersController(Seeder seeder)
-        {
-            _members = seeder.Seed<Member>();
-        }
+		public MembersController(Seeder seeder)
+		{
+			_members = seeder.Seed<Member>();
+		}
 
-        [HttpGet]
-        [Route("{id:Guid}", Name = "get-member")]
-        public IHttpActionResult Get(Guid id)
-        {
-            var member = _members.SingleOrDefault(i => i.Id == id);
-            return member != null ? Ok(member) : NotFound() as IHttpActionResult;
-        }
+		[HttpGet]
+		[Route("{id:Guid}", Name = "get-member")]
+		public IHttpActionResult Get(Guid id)
+		{
+			var member = _members.SingleOrDefault(i => i.Id == id);
+			return member != null ? Ok(member) : NotFound() as IHttpActionResult;
+		}
 
-        [HttpGet]
-        [Route(Name = "get-members")]
-        public IHttpActionResult GetAll(Guid? guildId = null)
-        {
-            var members = _members.Where(m => m.GuildId == guildId || guildId == null).ToList();
-            return Ok(members);
-        }
+		[HttpGet]
+		[Route(Name = "get-members")]
+		public IHttpActionResult GetAll(Guid? guildId = null)
+		{
+			var members = _members.Where(m => m.GuildId == guildId || guildId == null).ToList();
+			return Ok(members);
+		}
 
-        [HttpPost]
-        [Route(Name = "create-member")]
-        public IHttpActionResult Create([FromBody] Member member)
-        {
-            return CreatedAtRoute("get-member", new { id = member.Id }, member);
-        }
+		[HttpPost]
+		[Route(Name = "create-member")]
+		public IHttpActionResult Create([FromBody] Member member)
+		{
+			return CreatedAtRoute("get-member", new {id = member.Id}, member);
+		}
 
-        [HttpPut]
-        [Route("{id:Guid}", Name = "update-member")]
-        public IHttpActionResult Update([FromBody] Member member)
-        {
-            return Ok(member);
-        }
+		[HttpPut]
+		[Route("{id:Guid}", Name = "update-member")]
+		public IHttpActionResult Update([FromBody] Member member)
+		{
+			return Ok(member);
+		}
 
-        [HttpPatch]
-        [Route("{id}/promote", Name = "promote-member")]
-        public IHttpActionResult Promote(Guid id)
-        {
-            var member = _members.SingleOrDefault(i => i.Id == id);
-            if (member == null) return NotFound();
-            member.IsGuildMaster = true;
-            return Ok(member);
-        }
+		[HttpPatch]
+		[Route("{id}/promote", Name = "promote-member")]
+		public IHttpActionResult Promote(Guid id)
+		{
+			var member = _members.SingleOrDefault(i => i.Id == id);
+			if (member == null) return NotFound();
+			member.IsGuildMaster = true;
+			return Ok(member);
+		}
 
-        [HttpPatch]
-        [Route("{id}/demote", Name = "demote-member")]
-        public IHttpActionResult Demote(Guid id)
-        {
-            var member = _members.SingleOrDefault(i => i.Id == id);
-            if (member == null) return NotFound();
-            member.IsGuildMaster = false;
-            return Ok(member);
-        }
+		[HttpPatch]
+		[Route("{id}/demote", Name = "demote-member")]
+		public IHttpActionResult Demote(Guid id)
+		{
+			var member = _members.SingleOrDefault(i => i.Id == id);
+			if (member == null) return NotFound();
+			member.IsGuildMaster = false;
+			return Ok(member);
+		}
 
-        [HttpPatch]
-        [Route("{id}/leave", Name = "leave-guild")]
-        public IHttpActionResult LeaveGuild(Guid id)
-        {
-            var member = _members.SingleOrDefault(i => i.Id == id);
-            if (member == null) return NotFound();
-            member.Guild = null;
-            member.GuildId = null;
-            return Ok(member);
-        }
-    }
+		[HttpPatch]
+		[Route("{id}/leave", Name = "leave-guild")]
+		public IHttpActionResult LeaveGuild(Guid id)
+		{
+			var member = _members.SingleOrDefault(i => i.Id == id);
+			if (member == null) return NotFound();
+			member.Guild = null;
+			member.GuildId = null;
+			return Ok(member);
+		}
+	}
 }

--- a/HateoasNet.Framework.Sample/Global.asax.cs
+++ b/HateoasNet.Framework.Sample/Global.asax.cs
@@ -3,16 +3,16 @@ using System.Web.Http;
 
 namespace HateoasNet.Framework.Sample
 {
-    public class MvcApplication : HttpApplication
-    {
-        protected void Application_Start()
-        {
-            GlobalConfiguration.Configure(config =>
-            {
-                FormattersConfig.RegisterFormatters(config);
+	public class MvcApplication : HttpApplication
+	{
+		protected void Application_Start()
+		{
+			GlobalConfiguration.Configure(config =>
+			{
+				FormattersConfig.RegisterFormatters(config);
 
-                RouteConfig.RegisterRoutes(config);
-            });
-        }
-    }
+				RouteConfig.RegisterRoutes(config);
+			});
+		}
+	}
 }

--- a/HateoasNet.Framework.Sample/HateoasConfigurations/GuildHateoasResource.cs
+++ b/HateoasNet.Framework.Sample/HateoasConfigurations/GuildHateoasResource.cs
@@ -3,13 +3,13 @@ using HateoasNet.Framework.Sample.Models;
 
 namespace HateoasNet.Framework.Sample.HateoasConfigurations
 {
-    public class GuildHateoasResource : IHateoasResourceConfiguration<Guild>
-    {
-        public void Configure(IHateoasResource<Guild> resource)
-        {
-            resource.HasLink("get-guild").HasRouteData(g => new { id = g.Id });
-            resource.HasLink("get-members").HasRouteData(g => new { guildId = g.Id });
-            resource.HasLink("update-guild").HasRouteData(e => new { id = e.Id });
-        }
-    }
+	public class GuildHateoasResource : IHateoasResourceConfiguration<Guild>
+	{
+		public void Configure(IHateoasResource<Guild> resource)
+		{
+			resource.HasLink("get-guild").HasRouteData(g => new {id = g.Id});
+			resource.HasLink("get-members").HasRouteData(g => new {guildId = g.Id});
+			resource.HasLink("update-guild").HasRouteData(e => new {id = e.Id});
+		}
+	}
 }

--- a/HateoasNet.Framework.Sample/HateoasConfigurations/InviteHateoasResource.cs
+++ b/HateoasNet.Framework.Sample/HateoasConfigurations/InviteHateoasResource.cs
@@ -3,25 +3,25 @@ using HateoasNet.Framework.Sample.Models;
 
 namespace HateoasNet.Framework.Sample.HateoasConfigurations
 {
-    public class InviteHateoasResource : IHateoasResourceConfiguration<Invite>
-    {
-        public void Configure(IHateoasResource<Invite> resource)
-        {
-            resource.HasLink("accept-invite")
-                    .HasRouteData(e => new { id = e.Id })
-                    .HasConditional(e => e.Status == InviteStatuses.Pending);
+	public class InviteHateoasResource : IHateoasResourceConfiguration<Invite>
+	{
+		public void Configure(IHateoasResource<Invite> resource)
+		{
+			resource.HasLink("accept-invite")
+			        .HasRouteData(e => new {id = e.Id})
+			        .HasConditional(e => e.Status == InviteStatuses.Pending);
 
-            resource.HasLink("decline-invite")
-                    .HasRouteData(e => new { id = e.Id })
-                    .HasConditional(e => e.Status == InviteStatuses.Pending);
+			resource.HasLink("decline-invite")
+			        .HasRouteData(e => new {id = e.Id})
+			        .HasConditional(e => e.Status == InviteStatuses.Pending);
 
-            resource.HasLink("cancel-invite")
-                    .HasRouteData(e => new { id = e.Id })
-                    .HasConditional(e => e.Status == InviteStatuses.Pending);
+			resource.HasLink("cancel-invite")
+			        .HasRouteData(e => new {id = e.Id})
+			        .HasConditional(e => e.Status == InviteStatuses.Pending);
 
-            resource.HasLink("get-invite").HasRouteData(i => new { id = i.Id });
-            resource.HasLink("get-guild").HasRouteData(i => new { id = i.GuildId });
-            resource.HasLink("get-member").HasRouteData(i => new { id = i.MemberId });
-        }
-    }
+			resource.HasLink("get-invite").HasRouteData(i => new {id = i.Id});
+			resource.HasLink("get-guild").HasRouteData(i => new {id = i.GuildId});
+			resource.HasLink("get-member").HasRouteData(i => new {id = i.MemberId});
+		}
+	}
 }

--- a/HateoasNet.Framework.Sample/HateoasConfigurations/ListGuildHateoasResource.cs
+++ b/HateoasNet.Framework.Sample/HateoasConfigurations/ListGuildHateoasResource.cs
@@ -1,15 +1,15 @@
-﻿using HateoasNet.Abstractions;
+﻿using System.Collections.Generic;
+using HateoasNet.Abstractions;
 using HateoasNet.Framework.Sample.Models;
-using System.Collections.Generic;
 
 namespace HateoasNet.Framework.Sample.HateoasConfigurations
 {
-    public class ListGuildHateoasResource : IHateoasResourceConfiguration<List<Guild>>
-    {
-        public void Configure(IHateoasResource<List<Guild>> resource)
-        {
-            resource.HasLink("get-guilds");
-            resource.HasLink("create-guild");
-        }
-    }
+	public class ListGuildHateoasResource : IHateoasResourceConfiguration<List<Guild>>
+	{
+		public void Configure(IHateoasResource<List<Guild>> resource)
+		{
+			resource.HasLink("get-guilds");
+			resource.HasLink("create-guild");
+		}
+	}
 }

--- a/HateoasNet.Framework.Sample/HateoasConfigurations/ListMemberHateoasResource.cs
+++ b/HateoasNet.Framework.Sample/HateoasConfigurations/ListMemberHateoasResource.cs
@@ -1,16 +1,16 @@
-﻿using HateoasNet.Abstractions;
+﻿using System.Collections.Generic;
+using HateoasNet.Abstractions;
 using HateoasNet.Framework.Sample.Models;
-using System.Collections.Generic;
 
 namespace HateoasNet.Framework.Sample.HateoasConfigurations
 {
-    public class ListMemberHateoasResource : IHateoasResourceConfiguration<List<Member>>
-    {
-        public void Configure(IHateoasResource<List<Member>> resource)
-        {
-            resource.HasLink("get-members");
-            resource.HasLink("invite-member");
-            resource.HasLink("create-member");
-        }
-    }
+	public class ListMemberHateoasResource : IHateoasResourceConfiguration<List<Member>>
+	{
+		public void Configure(IHateoasResource<List<Member>> resource)
+		{
+			resource.HasLink("get-members");
+			resource.HasLink("invite-member");
+			resource.HasLink("create-member");
+		}
+	}
 }

--- a/HateoasNet.Framework.Sample/HateoasConfigurations/PaginationInviteHateoasResource.cs
+++ b/HateoasNet.Framework.Sample/HateoasConfigurations/PaginationInviteHateoasResource.cs
@@ -4,12 +4,12 @@ using HateoasNet.Resources;
 
 namespace HateoasNet.Framework.Sample.HateoasConfigurations
 {
-    public class PaginationInviteHateoasResource : IHateoasResourceConfiguration<Pagination<Invite>>
-    {
-        public void Configure(IHateoasResource<Pagination<Invite>> resource)
-        {
-            resource.HasLink("get-invites");
-            resource.HasLink("invite-member");
-        }
-    }
+	public class PaginationInviteHateoasResource : IHateoasResourceConfiguration<Pagination<Invite>>
+	{
+		public void Configure(IHateoasResource<Pagination<Invite>> resource)
+		{
+			resource.HasLink("get-invites");
+			resource.HasLink("invite-member");
+		}
+	}
 }

--- a/HateoasNet.Framework.Sample/JsonData/Seeder.cs
+++ b/HateoasNet.Framework.Sample/JsonData/Seeder.cs
@@ -1,17 +1,17 @@
-﻿using Newtonsoft.Json;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Web.Hosting;
+using Newtonsoft.Json;
 
 namespace HateoasNet.Framework.Sample.JsonData
 {
-    public class Seeder
-    {
-        internal List<T> Seed<T>() where T : class
-        {
-            var filepath = HostingEnvironment.MapPath($"~/JsonData/{typeof(T).Name.ToLower()}s.json");
-            using var stream = new StreamReader(filepath);
-            return JsonConvert.DeserializeObject<List<T>>(stream.ReadToEnd());
-        }
-    }
+	public class Seeder
+	{
+		internal List<T> Seed<T>() where T : class
+		{
+			var filepath = HostingEnvironment.MapPath($"~/JsonData/{typeof(T).Name.ToLower()}s.json");
+			using var stream = new StreamReader(filepath);
+			return JsonConvert.DeserializeObject<List<T>>(stream.ReadToEnd());
+		}
+	}
 }

--- a/HateoasNet.Framework.Sample/Models/Guild.cs
+++ b/HateoasNet.Framework.Sample/Models/Guild.cs
@@ -1,14 +1,14 @@
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace HateoasNet.Framework.Sample.Models
 {
-    public class Guild
-    {
-        public Guid Id { get; set; } = Guid.NewGuid();
-        public string Name { get; set; }
-        [JsonIgnore] public ICollection<Member> Members { get; set; } = new List<Member>();
-        [JsonIgnore] public ICollection<Invite> Invites { get; set; } = new List<Invite>();
-    }
+	public class Guild
+	{
+		public Guid Id { get; set; } = Guid.NewGuid();
+		public string Name { get; set; }
+		[JsonIgnore] public ICollection<Member> Members { get; set; } = new List<Member>();
+		[JsonIgnore] public ICollection<Invite> Invites { get; set; } = new List<Invite>();
+	}
 }

--- a/HateoasNet.Framework.Sample/Models/Invite.cs
+++ b/HateoasNet.Framework.Sample/Models/Invite.cs
@@ -1,20 +1,20 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace HateoasNet.Framework.Sample.Models
 {
-    public class Invite
-    {
-        public Guid Id { get; set; } = Guid.NewGuid();
-        public InviteStatuses Status { get; set; } = InviteStatuses.Pending;
-        public Guid GuildId { get; set; }
-        public Guid MemberId { get; set; }
-        [JsonIgnore] public Member Member { get; set; }
-        [JsonIgnore] public Guild Guild { get; set; }
-    }
+	public class Invite
+	{
+		public Guid Id { get; set; } = Guid.NewGuid();
+		public InviteStatuses Status { get; set; } = InviteStatuses.Pending;
+		public Guid GuildId { get; set; }
+		public Guid MemberId { get; set; }
+		[JsonIgnore] public Member Member { get; set; }
+		[JsonIgnore] public Guild Guild { get; set; }
+	}
 
-    public enum InviteStatuses : short
-    {
+	public enum InviteStatuses : short
+	{
         /// <summary>
         ///   Waiting for an answer as accepted, declined or canceled
         /// </summary>
@@ -34,5 +34,5 @@ namespace HateoasNet.Framework.Sample.Models
         ///   Canceled by inviting guild
         /// </summary>
         Canceled
-    }
+	}
 }

--- a/HateoasNet.Framework.Sample/Models/Member.cs
+++ b/HateoasNet.Framework.Sample/Models/Member.cs
@@ -1,14 +1,14 @@
-using Newtonsoft.Json;
 using System;
+using Newtonsoft.Json;
 
 namespace HateoasNet.Framework.Sample.Models
 {
-    public class Member
-    {
-        public Guid Id { get; set; } = Guid.NewGuid();
-        public string Name { get; set; }
-        public bool IsGuildMaster { get; set; }
-        public Guid? GuildId { get; set; }
-        [JsonIgnore] public Guild Guild { get; set; }
-    }
+	public class Member
+	{
+		public Guid Id { get; set; } = Guid.NewGuid();
+		public string Name { get; set; }
+		public bool IsGuildMaster { get; set; }
+		public Guid? GuildId { get; set; }
+		[JsonIgnore] public Guild Guild { get; set; }
+	}
 }

--- a/HateoasNet.Framework.Sample/Web.config
+++ b/HateoasNet.Framework.Sample/Web.config
@@ -46,7 +46,7 @@
 <system.codedom>
 <compilers>
 <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701" />
-<compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
+<compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:testeeMYTYPE=\&quot;Web\&quot; /optionInfer+" />
 </compilers>
 </system.codedom>
 </configuration>

--- a/HateoasNet.Framework.Sample/packages.config
+++ b/HateoasNet.Framework.Sample/packages.config
@@ -12,6 +12,6 @@
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
   <package id="Unity.Abstractions" version="5.11.5" targetFramework="net472" />
   <package id="Unity.AspNet.WebApi" version="5.11.1" targetFramework="net472" />
-  <package id="Unity.Container" version="5.11.7" targetFramework="net472" />
+  <package id="Unity.GetGetContainer" version="5.11.7" targetFramework="net472" />
   <package id="WebActivatorEx" version="2.2.0" targetFramework="net472" />
 </packages>

--- a/HateoasNet.Framework.Sample/packages.config
+++ b/HateoasNet.Framework.Sample/packages.config
@@ -12,6 +12,6 @@
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
   <package id="Unity.Abstractions" version="5.11.5" targetFramework="net472" />
   <package id="Unity.AspNet.WebApi" version="5.11.1" targetFramework="net472" />
-  <package id="Unity.GetGetContainer" version="5.11.7" targetFramework="net472" />
+  <package id="Unity.Container" version="5.11.7" targetFramework="net472" />
   <package id="WebActivatorEx" version="2.2.0" targetFramework="net472" />
 </packages>

--- a/HateoasNet.Framework.Tests/Factories/ResourceLinkFactoryTestData.cs
+++ b/HateoasNet.Framework.Tests/Factories/ResourceLinkFactoryTestData.cs
@@ -2,15 +2,15 @@
 
 namespace HateoasNet.Framework.Tests.Factories
 {
-    public class ResourceLinkFactoryTestData
-    {
-        public string BaseUrl { get; set; }
-        public string ControllerName { get; set; }
-        public string Prefix { get; set; }
-        public string RouteName { get; set; }
-        public string Method { get; set; }
-        public string Template { get; set; }
-        public string ExpectedUrl { get; set; }
-        public IDictionary<string, object> RouteValues { get; set; }
-    }
+	public class ResourceLinkFactoryTestData
+	{
+		public string BaseUrl { get; set; }
+		public string ControllerName { get; set; }
+		public string Prefix { get; set; }
+		public string RouteName { get; set; }
+		public string Method { get; set; }
+		public string Template { get; set; }
+		public string ExpectedUrl { get; set; }
+		public IDictionary<string, object> RouteValues { get; set; }
+	}
 }

--- a/HateoasNet.Framework.Tests/Factories/ResourceLinkFactoryTests.cs
+++ b/HateoasNet.Framework.Tests/Factories/ResourceLinkFactoryTests.cs
@@ -1,8 +1,4 @@
-﻿using HateoasNet.Abstractions;
-using HateoasNet.Framework.Factories;
-using HateoasNet.Resources;
-using Moq;
-using System;
+﻿using System;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
@@ -10,128 +6,134 @@ using System.Net.Http;
 using System.Web;
 using System.Web.Http;
 using System.Web.Http.Controllers;
+using HateoasNet.Abstractions;
+using HateoasNet.Framework.Factories;
+using HateoasNet.Resources;
+using Moq;
 using Xunit;
 
 namespace HateoasNet.Framework.Tests.Factories
 {
-    public class ResourceLinkFactoryTests : IDisposable
-    {
-        [Fact]
-        [Trait(nameof(IResourceLinkFactory), "Instantiation")]
-        public void New_WithValidParameters_ReturnsResourceLinkFactory()
-        {
-            // act
-            var sut = GenerateDefaultSut();
+	public class ResourceLinkFactoryTests : IDisposable
+	{
+		/// <inheritdoc />
+		public void Dispose()
+		{
+			GC.SuppressFinalize(this);
+		}
 
-            // assert
-            Assert.IsAssignableFrom<IResourceLinkFactory>(sut);
-            Assert.IsType<ResourceLinkFactory>(sut);
-        }
+		[Theory]
+		[UrlResourceLinkData]
+		[Trait(nameof(IResourceLinkFactory), nameof(IResourceLinkFactory.Create))]
+		public void Create_WithValidParameters_ReturnsValidResourceLink(ResourceLinkFactoryTestData data)
+		{
+			// arrange
+			var sut = GenerateFullSut(data);
 
-        [Theory]
-        [UrlResourceLinkData]
-        [Trait(nameof(IResourceLinkFactory), nameof(IResourceLinkFactory.Create))]
-        public void Create_WithValidParameters_ReturnsValidResourceLink(ResourceLinkFactoryTestData data)
-        {
-            // arrange
-            var sut = GenerateFullSut(data);
+			// act
+			var resourceLink = sut.Create(data.RouteName, data.RouteValues);
 
-            // act
-            var resourceLink = sut.Create(data.RouteName, data.RouteValues);
+			// assert
+			Assert.IsType<ResourceLink>(resourceLink);
+			Assert.NotNull(resourceLink);
+			Assert.Equal(data.ExpectedUrl, resourceLink.Href, StringComparer.OrdinalIgnoreCase);
+			Assert.Equal(data.RouteName, resourceLink.Rel, StringComparer.OrdinalIgnoreCase);
+			Assert.Equal(data.Method, resourceLink.Method, StringComparer.OrdinalIgnoreCase);
+		}
 
-            // assert
-            Assert.IsType<ResourceLink>(resourceLink);
-            Assert.NotNull(resourceLink);
-            Assert.Equal(data.ExpectedUrl, resourceLink.Href, StringComparer.OrdinalIgnoreCase);
-            Assert.Equal(data.RouteName, resourceLink.Rel, StringComparer.OrdinalIgnoreCase);
-            Assert.Equal(data.Method, resourceLink.Method, StringComparer.OrdinalIgnoreCase);
-        }
+		[Theory]
+		[UrlResourceLinkData]
+		[Trait(nameof(IResourceLinkFactory), nameof(ResourceLinkFactory.GetRouteUrl))]
+		public void GetRouteUrl_WithValidParameters_ReturnsRouteUrlString(ResourceLinkFactoryTestData data)
+		{
+			var sut = GenerateFullSut(data);
 
-        [Theory, UrlResourceLinkData, Trait(nameof(IResourceLinkFactory), nameof(ResourceLinkFactory.GetRouteUrl))]
-        public void GetRouteUrl_WithValidParameters_ReturnsRouteUrlString(ResourceLinkFactoryTestData data)
-        {
-            var sut = GenerateFullSut(data);
+			// act
+			var actual = sut.GetRouteUrl(data.RouteName, data.RouteValues);
 
-            // act
-            var actual = sut.GetRouteUrl(data.RouteName, data.RouteValues);
+			// assert
+			Assert.Equal(data.ExpectedUrl, actual, StringComparer.OrdinalIgnoreCase);
+		}
 
-            // assert
-            Assert.Equal(data.ExpectedUrl, actual, StringComparer.OrdinalIgnoreCase);
-        }
+		[Theory]
+		[InlineData("")]
+		[InlineData(null)]
+		[Trait(nameof(IResourceLinkFactory), nameof(IResourceLinkFactory.Create))]
+		[Trait(nameof(IResourceLinkFactory), "Exceptions")]
+		public void Create_WithRouteNameNullOrWhiteSpace_Throws_ArgumentNullException(string rel)
+		{
+			// arrange
+			var sut = GenerateDefaultSut();
+			const string parameterName = "rel";
 
-        [Theory]
-        [InlineData("")]
-        [InlineData(null)]
-        [Trait(nameof(IResourceLinkFactory), nameof(IResourceLinkFactory.Create))]
-        [Trait(nameof(IResourceLinkFactory), "Exceptions")]
-        public void Create_WithRouteNameNullOrWhiteSpace_Throws_ArgumentNullException(string rel)
-        {
-            // arrange
-            var sut = GenerateDefaultSut();
-            const string parameterName = "rel";
+			// act
+			Action actual = () => sut.Create(rel, null);
 
-            // act
-            Action actual = () => sut.Create(rel, null);
+			// act
+			Assert.Throws<ArgumentNullException>(parameterName, actual);
+		}
 
-            // act
-            Assert.Throws<ArgumentNullException>(parameterName, actual);
-        }
+		[Theory]
+		[InlineData("")]
+		[InlineData(null)]
+		[Trait(nameof(IResourceLinkFactory), nameof(ResourceLinkFactory.GetRouteUrl))]
+		[Trait(nameof(IResourceLinkFactory), "Exceptions")]
+		public void GetRouteUrl_WithRouteNameNullOrWhiteSpace_Throws_ArgumentNullException(string routeName)
+		{
+			// arrange
+			var sut = GenerateDefaultSut();
+			const string parameterName = "routeName";
 
-        [Theory]
-        [InlineData("")]
-        [InlineData(null)]
-        [Trait(nameof(IResourceLinkFactory), nameof(ResourceLinkFactory.GetRouteUrl))]
-        [Trait(nameof(IResourceLinkFactory), "Exceptions")]
-        public void GetRouteUrl_WithRouteNameNullOrWhiteSpace_Throws_ArgumentNullException(string routeName)
-        {
-            // arrange
-            var sut = GenerateDefaultSut();
-            const string parameterName = "routeName";
+			// act
+			Action actual = () => sut.GetRouteUrl(routeName, null);
 
-            // act
-            Action actual = () => sut.GetRouteUrl(routeName, null);
+			// assert
+			Assert.Throws<ArgumentNullException>(parameterName, actual);
+		}
 
-            // assert
-            Assert.Throws<ArgumentNullException>(parameterName, actual);
-        }
+		private ResourceLinkFactory GenerateDefaultSut()
+		{
+			return new ResourceLinkFactory(new[] {new Mock<HttpActionDescriptor>().Object});
+		}
 
-        private ResourceLinkFactory GenerateDefaultSut()
-        {
-            return new ResourceLinkFactory(new[] { new Mock<HttpActionDescriptor>().Object });
-        }
+		// manually arrange aspnet web api dummies and mocks
+		private ResourceLinkFactory GenerateFullSut(ResourceLinkFactoryTestData data)
+		{
+			var config = new Mock<HttpConfiguration>().Object;
+			var prefix = new RoutePrefixAttribute(data.Prefix);
+			var controllerDescriptor =
+				new TestControllerDescriptor(config, data.ControllerName, typeof(ApiController), prefix);
+			var actionParameters =
+				data.RouteValues.Keys.Aggregate(new Collection<HttpParameterDescriptor>(),
+				                                (collection, parameterName) =>
+				                                {
+					                                var mockParameterDescriptor = new Mock<HttpParameterDescriptor>();
+					                                mockParameterDescriptor.Setup(x => x.ParameterName).Returns(parameterName);
+					                                collection.Add(mockParameterDescriptor.Object);
+					                                return collection;
+				                                });
+			var methodInfo = new TestMethodInfo(new RouteAttribute(data.Template) {Name = data.RouteName});
+			var actionDescriptor = new TestActionDescriptor(controllerDescriptor, methodInfo, actionParameters);
+			actionDescriptor.SupportedHttpMethods.Add(new HttpMethod(data.Method));
 
-        // manually arrange aspnet web api dummies and mocks
-        private ResourceLinkFactory GenerateFullSut(ResourceLinkFactoryTestData data)
-        {
-            var config = new Mock<HttpConfiguration>().Object;
-            var prefix = new RoutePrefixAttribute(data.Prefix);
-            var controllerDescriptor =
-                new TestControllerDescriptor(config, data.ControllerName, typeof(ApiController), prefix);
-            var actionParameters =
-                data.RouteValues.Keys.Aggregate(new Collection<HttpParameterDescriptor>(),
-                                                (collection, parameterName) =>
-                                                {
-                                                    var mockParameterDescriptor = new Mock<HttpParameterDescriptor>();
-                                                    mockParameterDescriptor.Setup(x => x.ParameterName).Returns(parameterName);
-                                                    collection.Add(mockParameterDescriptor.Object);
-                                                    return collection;
-                                                });
-            var methodInfo = new TestMethodInfo(new RouteAttribute(data.Template) { Name = data.RouteName });
-            var actionDescriptor = new TestActionDescriptor(controllerDescriptor, methodInfo, actionParameters);
-            actionDescriptor.SupportedHttpMethods.Add(new HttpMethod(data.Method));
+			// httpContext
+			var request = new HttpRequest("", data.BaseUrl, "");
+			var response = new HttpResponse(new StringWriter());
+			HttpContext.Current = new HttpContext(request, response);
 
-            // httpContext
-            var request = new HttpRequest("", data.BaseUrl, "");
-            var response = new HttpResponse(new StringWriter());
-            HttpContext.Current = new HttpContext(request, response);
+			return new ResourceLinkFactory(new[] {actionDescriptor});
+		}
 
-            return new ResourceLinkFactory(new[] { actionDescriptor });
-        }
+		[Fact]
+		[Trait(nameof(IResourceLinkFactory), "Instantiation")]
+		public void New_WithValidParameters_ReturnsResourceLinkFactory()
+		{
+			// act
+			var sut = GenerateDefaultSut();
 
-        /// <inheritdoc />
-        public void Dispose()
-        {
-            GC.SuppressFinalize(this);
-        }
-    }
+			// assert
+			Assert.IsAssignableFrom<IResourceLinkFactory>(sut);
+			Assert.IsType<ResourceLinkFactory>(sut);
+		}
+	}
 }

--- a/HateoasNet.Framework.Tests/Factories/TestActionDescriptor.cs
+++ b/HateoasNet.Framework.Tests/Factories/TestActionDescriptor.cs
@@ -15,6 +15,8 @@ namespace HateoasNet.Framework.Tests.Factories
     internal class TestActionDescriptor : HttpActionDescriptor
     {
         private readonly Collection<HttpParameterDescriptor> _parameterDescriptors;
+
+        // ReSharper disable once UnusedAutoPropertyAccessor.Global
         public MethodInfo MethodInfo { get; }
 
         public TestActionDescriptor(HttpControllerDescriptor controllerDescriptor,
@@ -37,9 +39,9 @@ namespace HateoasNet.Framework.Tests.Factories
                                                   CancellationToken cancellationToken) => null;
 
         /// <inheritdoc />
-        public override string ActionName { get; }
+        public override string ActionName => "TestAction";
 
         /// <inheritdoc />
-        public override Type ReturnType { get; }
+        public override Type ReturnType => typeof(object);
     }
 }

--- a/HateoasNet.Framework.Tests/Factories/TestActionDescriptor.cs
+++ b/HateoasNet.Framework.Tests/Factories/TestActionDescriptor.cs
@@ -9,39 +9,48 @@ using System.Web.Http.Controllers;
 namespace HateoasNet.Framework.Tests.Factories
 {
     /// <summary>
-    /// 	Custom dummy of HttpActionDescriptor abstract class to get RouteAttribute
-    /// 	and HttpMethod from a Controller Action MethodInfo for testing purposes
+    ///   Custom dummy of HttpActionDescriptor abstract class to get RouteAttribute
+    ///   and HttpMethod from a Controller Action MethodInfo for testing purposes
     /// </summary>
     internal class TestActionDescriptor : HttpActionDescriptor
-    {
-        private readonly Collection<HttpParameterDescriptor> _parameterDescriptors;
+	{
+		private readonly Collection<HttpParameterDescriptor> _parameterDescriptors;
 
-        // ReSharper disable once UnusedAutoPropertyAccessor.Global
-        public MethodInfo MethodInfo { get; }
+		public TestActionDescriptor(HttpControllerDescriptor controllerDescriptor,
+		                            MethodInfo methodInfo,
+		                            Collection<HttpParameterDescriptor> parameterDescriptors) : base(controllerDescriptor)
+		{
+			_parameterDescriptors = parameterDescriptors;
+			MethodInfo = methodInfo;
+		}
 
-        public TestActionDescriptor(HttpControllerDescriptor controllerDescriptor,
-                                    MethodInfo methodInfo,
-                                    Collection<HttpParameterDescriptor> parameterDescriptors) : base(controllerDescriptor)
-        {
-            _parameterDescriptors = parameterDescriptors;
-            MethodInfo = methodInfo;
-        }
+		// ReSharper disable once UnusedAutoPropertyAccessor.Global
+		public MethodInfo MethodInfo { get; }
 
-        /// <inheritdoc />
-        public override Collection<HttpParameterDescriptor> GetParameters() => _parameterDescriptors;
+		/// <inheritdoc />
+		public override string ActionName => "TestAction";
 
-        /// <inheritdoc />
-        public override Collection<T> GetCustomAttributes<T>() => new Collection<T>();
+		/// <inheritdoc />
+		public override Type ReturnType => typeof(object);
 
-        /// <inheritdoc />
-        public override Task<object> ExecuteAsync(HttpControllerContext controllerContext,
-                                                  IDictionary<string, object> arguments,
-                                                  CancellationToken cancellationToken) => null;
+		/// <inheritdoc />
+		public override Collection<HttpParameterDescriptor> GetParameters()
+		{
+			return _parameterDescriptors;
+		}
 
-        /// <inheritdoc />
-        public override string ActionName => "TestAction";
+		/// <inheritdoc />
+		public override Collection<T> GetCustomAttributes<T>()
+		{
+			return new Collection<T>();
+		}
 
-        /// <inheritdoc />
-        public override Type ReturnType => typeof(object);
-    }
+		/// <inheritdoc />
+		public override Task<object> ExecuteAsync(HttpControllerContext controllerContext,
+		                                          IDictionary<string, object> arguments,
+		                                          CancellationToken cancellationToken)
+		{
+			return null;
+		}
+	}
 }

--- a/HateoasNet.Framework.Tests/Factories/TestControllerDescriptor.cs
+++ b/HateoasNet.Framework.Tests/Factories/TestControllerDescriptor.cs
@@ -5,22 +5,22 @@ using System.Web.Http.Controllers;
 
 namespace HateoasNet.Framework.Tests.Factories
 {
-    public class TestControllerDescriptor : HttpControllerDescriptor
-    {
-        public TestControllerDescriptor(HttpConfiguration configuration, string controllerName,
-                                        Type controllerType, RoutePrefixAttribute prefix)
-            : base(configuration, controllerName, controllerType)
-        {
-            RoutePrefix = prefix;
-        }
+	public class TestControllerDescriptor : HttpControllerDescriptor
+	{
+		public TestControllerDescriptor(HttpConfiguration configuration, string controllerName,
+		                                Type controllerType, RoutePrefixAttribute prefix)
+			: base(configuration, controllerName, controllerType)
+		{
+			RoutePrefix = prefix;
+		}
 
-        public RoutePrefixAttribute RoutePrefix { get; private set; }
+		public RoutePrefixAttribute RoutePrefix { get; }
 
-        public override Collection<T> GetCustomAttributes<T>() where T : class
-        {
-            return typeof(T) == RoutePrefix.GetType()
-                 ? new Collection<T> { RoutePrefix as T }
-                 : base.GetCustomAttributes<T>();
-        }
-    }
+		public override Collection<T> GetCustomAttributes<T>() where T : class
+		{
+			return typeof(T) == RoutePrefix.GetType()
+				? new Collection<T> {RoutePrefix as T}
+				: base.GetCustomAttributes<T>();
+		}
+	}
 }

--- a/HateoasNet.Framework.Tests/Factories/TestMethodInfo.cs
+++ b/HateoasNet.Framework.Tests/Factories/TestMethodInfo.cs
@@ -6,78 +6,78 @@ using System.Web.Http;
 namespace HateoasNet.Framework.Tests.Factories
 {
     /// <summary>
-    /// 	Custom dummy of MethodInfo abstract class to get RouteAttribute values from a
-    /// 	Controller Action MethodInfo for testing purposes
+    ///   Custom dummy of MethodInfo abstract class to get RouteAttribute values from a
+    ///   Controller Action MethodInfo for testing purposes
     /// </summary>
     internal class TestMethodInfo : MethodInfo
-    {
-        private readonly RouteAttribute _routeAttribute;
+	{
+		private readonly RouteAttribute _routeAttribute;
 
-        public TestMethodInfo(RouteAttribute routeAttribute)
-        {
-            _routeAttribute = routeAttribute;
-        }
+		public TestMethodInfo(RouteAttribute routeAttribute)
+		{
+			_routeAttribute = routeAttribute;
+		}
 
-        /// <inheritdoc />
-        public override object[] GetCustomAttributes(bool inherit)
-        {
-            return new object[] { _routeAttribute };
-        }
+		/// <inheritdoc />
+		// ReSharper disable once UnassignedGetOnlyAutoProperty
+		public override ICustomAttributeProvider ReturnTypeCustomAttributes { get; }
 
-        /// <inheritdoc />
-        public override bool IsDefined(Type attributeType, bool inherit)
-        {
-            return false;
-        }
+		/// <inheritdoc />
+		public override string Name => "TestAction";
 
-        /// <inheritdoc />
-        public override ParameterInfo[] GetParameters()
-        {
-            return new ParameterInfo[] { };
-        }
+		/// <inheritdoc />
+		public override Type DeclaringType => typeof(object);
 
-        /// <inheritdoc />
-        public override MethodImplAttributes GetMethodImplementationFlags()
-        {
-            return MethodImplAttributes.IL;
-        }
+		/// <inheritdoc />
+		public override Type ReflectedType => typeof(object);
 
-        /// <inheritdoc />
-        public override object Invoke(object obj, BindingFlags invokeAttr, Binder binder, object[] parameters,
-                                      CultureInfo culture)
-        {
-            return null;
-        }
+		/// <inheritdoc />
+		public override RuntimeMethodHandle MethodHandle => new RuntimeMethodHandle();
 
-        /// <inheritdoc />
-        public override MethodInfo GetBaseDefinition()
-        {
-            return null;
-        }
+		/// <inheritdoc />
+		public override MethodAttributes Attributes => new MethodAttributes();
 
-        /// <inheritdoc />
-        // ReSharper disable once UnassignedGetOnlyAutoProperty
-        public override ICustomAttributeProvider ReturnTypeCustomAttributes { get; }
+		/// <inheritdoc />
+		public override object[] GetCustomAttributes(bool inherit)
+		{
+			return new object[] {_routeAttribute};
+		}
 
-        /// <inheritdoc />
-        public override string Name => "TestAction";
+		/// <inheritdoc />
+		public override bool IsDefined(Type attributeType, bool inherit)
+		{
+			return false;
+		}
 
-        /// <inheritdoc />
-        public override Type DeclaringType => typeof(object);
+		/// <inheritdoc />
+		public override ParameterInfo[] GetParameters()
+		{
+			return new ParameterInfo[] { };
+		}
 
-        /// <inheritdoc />
-        public override Type ReflectedType => typeof(object);
+		/// <inheritdoc />
+		public override MethodImplAttributes GetMethodImplementationFlags()
+		{
+			return MethodImplAttributes.IL;
+		}
 
-        /// <inheritdoc />
-        public override RuntimeMethodHandle MethodHandle => new RuntimeMethodHandle();
+		/// <inheritdoc />
+		public override object Invoke(object obj, BindingFlags invokeAttr, Binder binder, object[] parameters,
+		                              CultureInfo culture)
+		{
+			return null;
+		}
 
-        /// <inheritdoc />
-        public override MethodAttributes Attributes => new MethodAttributes();
+		/// <inheritdoc />
+		public override MethodInfo GetBaseDefinition()
+		{
+			return null;
+		}
 
-        /// <inheritdoc />
-        public override object[] GetCustomAttributes(Type attributeType, bool inherit)
-        {
-            return new object[] { _routeAttribute };
-        }
-    }
+		/// <inheritdoc />
+		public override object[] GetCustomAttributes(Type attributeType, bool inherit)
+		{
+			return new object[] {_routeAttribute};
+		}
+	}
 }

--- a/HateoasNet.Framework.Tests/Factories/TestMethodInfo.cs
+++ b/HateoasNet.Framework.Tests/Factories/TestMethodInfo.cs
@@ -56,22 +56,23 @@ namespace HateoasNet.Framework.Tests.Factories
         }
 
         /// <inheritdoc />
+        // ReSharper disable once UnassignedGetOnlyAutoProperty
         public override ICustomAttributeProvider ReturnTypeCustomAttributes { get; }
 
         /// <inheritdoc />
-        public override string Name { get; }
+        public override string Name => "TestAction";
 
         /// <inheritdoc />
-        public override Type DeclaringType { get; }
+        public override Type DeclaringType => typeof(object);
 
         /// <inheritdoc />
-        public override Type ReflectedType { get; }
+        public override Type ReflectedType => typeof(object);
 
         /// <inheritdoc />
-        public override RuntimeMethodHandle MethodHandle { get; }
+        public override RuntimeMethodHandle MethodHandle => new RuntimeMethodHandle();
 
         /// <inheritdoc />
-        public override MethodAttributes Attributes { get; }
+        public override MethodAttributes Attributes => new MethodAttributes();
 
         /// <inheritdoc />
         public override object[] GetCustomAttributes(Type attributeType, bool inherit)

--- a/HateoasNet.Framework.Tests/Factories/UrlResourceLinkDataAttribute.cs
+++ b/HateoasNet.Framework.Tests/Factories/UrlResourceLinkDataAttribute.cs
@@ -6,97 +6,97 @@ using Xunit.Sdk;
 
 namespace HateoasNet.Framework.Tests.Factories
 {
-    public class UrlResourceLinkDataAttribute : DataAttribute
-    {
-        /// <inheritdoc />
-        public override IEnumerable<object[]> GetData(MethodInfo testMethod)
-        {
-            var id = Guid.NewGuid();
-            var baseUrls = new[]
-            {
-                "http://hateoasNet.io:5000/api",
-                "https://hateoasNet.framework:5001/api",
-                "http://hateoasNet.core:5002/api",
-                "http://hateoasNet.dummy:5000/api/v1",
-                "http://hateoasNet.test:5000/api/v2",
-            };
-            var controllerNames = Enumerable.Range(1, 5).Select(i => "controller" + i).ToArray();
-            var testRoutes = Enumerable.Range(1, 5).Select(i => "route" + i).ToArray();
+	public class UrlResourceLinkDataAttribute : DataAttribute
+	{
+		/// <inheritdoc />
+		public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+		{
+			var id = Guid.NewGuid();
+			var baseUrls = new[]
+			{
+				"http://hateoasNet.io:5000/api",
+				"https://hateoasNet.framework:5001/api",
+				"http://hateoasNet.core:5002/api",
+				"http://hateoasNet.dummy:5000/api/v1",
+				"http://hateoasNet.test:5000/api/v2"
+			};
+			var controllerNames = Enumerable.Range(1, 5).Select(i => "controller" + i).ToArray();
+			var testRoutes = Enumerable.Range(1, 5).Select(i => "route" + i).ToArray();
 
-            yield return new object[]
-            {
-                new ResourceLinkFactoryTestData
-                {
-                    BaseUrl = baseUrls[0],
-                    ControllerName = controllerNames[0],
-                    Prefix = $"api/{controllerNames[0]}",
-                    RouteName = testRoutes[0],
-                    Method = "DELETE",
-                    Template = "{id:guid}",
-                    RouteValues = new Dictionary<string, object> {{"id", id}},
-                    ExpectedUrl = $"{baseUrls[0]}/{controllerNames[0]}/{id}",
-                }
-            };
+			yield return new object[]
+			{
+				new ResourceLinkFactoryTestData
+				{
+					BaseUrl = baseUrls[0],
+					ControllerName = controllerNames[0],
+					Prefix = $"api/{controllerNames[0]}",
+					RouteName = testRoutes[0],
+					Method = "DELETE",
+					Template = "{id:guid}",
+					RouteValues = new Dictionary<string, object> {{"id", id}},
+					ExpectedUrl = $"{baseUrls[0]}/{controllerNames[0]}/{id}"
+				}
+			};
 
-            yield return new object[]
-            {
-                new ResourceLinkFactoryTestData
-                {
-                    BaseUrl = baseUrls[1],
-                    ControllerName = controllerNames[1],
-                    Prefix = $"api/{controllerNames[1]}",
-                    RouteName = testRoutes[1],
-                    Method = "PATCH",
-                    Template = "{id:guid}",
-                    RouteValues = new Dictionary<string, object> {{"id", id}},
-                    ExpectedUrl = $"{baseUrls[1]}/{controllerNames[1]}/{id}",
-                }
-            };
+			yield return new object[]
+			{
+				new ResourceLinkFactoryTestData
+				{
+					BaseUrl = baseUrls[1],
+					ControllerName = controllerNames[1],
+					Prefix = $"api/{controllerNames[1]}",
+					RouteName = testRoutes[1],
+					Method = "PATCH",
+					Template = "{id:guid}",
+					RouteValues = new Dictionary<string, object> {{"id", id}},
+					ExpectedUrl = $"{baseUrls[1]}/{controllerNames[1]}/{id}"
+				}
+			};
 
-            yield return new object[]
-            {
-                new ResourceLinkFactoryTestData
-                {
-                    BaseUrl = baseUrls[2],
-                    ControllerName = controllerNames[2],
-                    Prefix = $"api/{controllerNames[2]}",
-                    RouteName = testRoutes[2],
-                    Method = "PUT",
-                    Template = "{id}",
-                    RouteValues = new Dictionary<string, object> {{"id", id}},
-                    ExpectedUrl = $"{baseUrls[2]}/{controllerNames[2]}/{id}",
-                }
-            };
+			yield return new object[]
+			{
+				new ResourceLinkFactoryTestData
+				{
+					BaseUrl = baseUrls[2],
+					ControllerName = controllerNames[2],
+					Prefix = $"api/{controllerNames[2]}",
+					RouteName = testRoutes[2],
+					Method = "PUT",
+					Template = "{id}",
+					RouteValues = new Dictionary<string, object> {{"id", id}},
+					ExpectedUrl = $"{baseUrls[2]}/{controllerNames[2]}/{id}"
+				}
+			};
 
-            yield return new object[]
-            {
-                new ResourceLinkFactoryTestData
-                {
-                    BaseUrl = baseUrls[3],
-                    ControllerName = controllerNames[3],
-                    Prefix = $"api/v1/{controllerNames[3]}",
-                    RouteName = testRoutes[3],
-                    Method = "POST",
-                    Template = "",
-                    RouteValues = new Dictionary<string, object>(),
-                    ExpectedUrl = $"{baseUrls[3]}/{controllerNames[3]}",
-                }
-            };
+			yield return new object[]
+			{
+				new ResourceLinkFactoryTestData
+				{
+					BaseUrl = baseUrls[3],
+					ControllerName = controllerNames[3],
+					Prefix = $"api/v1/{controllerNames[3]}",
+					RouteName = testRoutes[3],
+					Method = "POST",
+					Template = "",
+					RouteValues = new Dictionary<string, object>(),
+					ExpectedUrl = $"{baseUrls[3]}/{controllerNames[3]}"
+				}
+			};
 
-            yield return new object[]
-            {
-                new ResourceLinkFactoryTestData
-                {
-                    BaseUrl = baseUrls[4],
-                    ControllerName = controllerNames[4],
-                    Prefix = $"api/v2/{controllerNames[4]}",
-                    RouteName = testRoutes[4],
-                    Method = "GET",
-                    Template = "",
-                    RouteValues = new Dictionary<string, object> {{"relationId", id}},
-                    ExpectedUrl = $"{baseUrls[4]}/{controllerNames[4]}?relationId={id}",
-                },
-            };
-        }
-    }
+			yield return new object[]
+			{
+				new ResourceLinkFactoryTestData
+				{
+					BaseUrl = baseUrls[4],
+					ControllerName = controllerNames[4],
+					Prefix = $"api/v2/{controllerNames[4]}",
+					RouteName = testRoutes[4],
+					Method = "GET",
+					Template = "",
+					RouteValues = new Dictionary<string, object> {{"relationId", id}},
+					ExpectedUrl = $"{baseUrls[4]}/{controllerNames[4]}?relationId={id}"
+				}
+			};
+		}
+	}
 }

--- a/HateoasNet.Framework.Tests/Formatting/FormattingDataAttribute.cs
+++ b/HateoasNet.Framework.Tests/Formatting/FormattingDataAttribute.cs
@@ -1,63 +1,63 @@
-using HateoasNet.Resources;
-using HateoasNet.TestingObjects;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using HateoasNet.Resources;
+using HateoasNet.TestingObjects;
 using Xunit.Sdk;
 
 namespace HateoasNet.Framework.Tests.Formatting
 {
-    public class FormattingDataAttribute : DataAttribute
-    {
-        public override IEnumerable<object[]> GetData(MethodInfo testMethod)
-        {
-            // Guid and DateTime values shared for serialization test
-            var sharedGuid = Guid.Parse("96685bc4-dcb7-4b22-90cc-ca83baff8186");
-            var sharedDateTime = DateTime.Parse("Fri, 1 May 2020 00:00:00Z");
+	public class FormattingDataAttribute : DataAttribute
+	{
+		public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+		{
+			// Guid and DateTime values shared for serialization test
+			var sharedGuid = Guid.Parse("96685bc4-dcb7-4b22-90cc-ca83baff8186");
+			var sharedDateTime = DateTime.Parse("Fri, 1 May 2020 00:00:00Z");
 
-            // dummies
-            var emptyLink = new ResourceLink("", "", "");
-            var testee = new Testee { Id = sharedGuid, CreatedDate = sharedDateTime };
-            var nestedTestee = new NestedTestee
-            {
-                Id = sharedGuid,
-                CreatedDate = sharedDateTime,
-                Nested = testee,
-                Collection = new List<Testee> { testee }
-            };
-            var genericTestee = new GenericTestee<Testee>
-            {
-                Nested = nestedTestee,
-                Id = sharedGuid,
-                CreatedDate = sharedDateTime,
-                Collection = new List<Testee> { testee, nestedTestee }
-            };
-            var testeeList = new List<Testee> { testee, nestedTestee, genericTestee };
-            var testeePagination = new Pagination<Testee>(testeeList, testeeList.Count, 5);
+			// dummies
+			var emptyLink = new ResourceLink("", "", "");
+			var testee = new Testee {Id = sharedGuid, CreatedDate = sharedDateTime};
+			var nestedTestee = new NestedTestee
+			{
+				Id = sharedGuid,
+				CreatedDate = sharedDateTime,
+				Nested = testee,
+				Collection = new List<Testee> {testee}
+			};
+			var genericTestee = new GenericTestee<Testee>
+			{
+				Nested = nestedTestee,
+				Id = sharedGuid,
+				CreatedDate = sharedDateTime,
+				Collection = new List<Testee> {testee, nestedTestee}
+			};
+			var testeeList = new List<Testee> {testee, nestedTestee, genericTestee};
+			var testeePagination = new Pagination<Testee>(testeeList, testeeList.Count, 5);
 
-            // resources
-            var resources = testeeList.Select(x =>
-            {
-                var resource = new SingleResource(x);
-                resource.Links.Add(emptyLink);
-                return resource;
-            }).ToList();
+			// resources
+			var resources = testeeList.Select(x =>
+			{
+				var resource = new SingleResource(x);
+				resource.Links.Add(emptyLink);
+				return resource;
+			}).ToList();
 
-            var enumerableResource = new EnumerableResource(resources);
-            enumerableResource.Links.Add(emptyLink);
-            var paginationResource = new PaginationResource(resources, resources.Count(), 5, 1);
-            paginationResource.Links.Add(emptyLink);
+			var enumerableResource = new EnumerableResource(resources);
+			enumerableResource.Links.Add(emptyLink);
+			var paginationResource = new PaginationResource(resources, resources.Count(), 5, 1);
+			paginationResource.Links.Add(emptyLink);
 
-            // expectedOutputs
-            var expectedSingleString = File.ReadAllText(Path.Combine("Serialization", "SingleResource.json"));
-            var expectedEnumerableString = File.ReadAllText(Path.Combine("Serialization", "EnumerableResource.json"));
-            var expectedPaginationString = File.ReadAllText(Path.Combine("Serialization", "PaginationResource.json"));
+			// expectedOutputs
+			var expectedSingleString = File.ReadAllText(Path.Combine("Serialization", "SingleResource.json"));
+			var expectedEnumerableString = File.ReadAllText(Path.Combine("Serialization", "EnumerableResource.json"));
+			var expectedPaginationString = File.ReadAllText(Path.Combine("Serialization", "PaginationResource.json"));
 
-            yield return new object[] { testee, resources.First(), expectedSingleString };
-            yield return new object[] { testeeList, enumerableResource, expectedEnumerableString };
-            yield return new object[] { testeePagination, paginationResource, expectedPaginationString };
-        }
-    }
+			yield return new object[] {testee, resources.First(), expectedSingleString};
+			yield return new object[] {testeeList, enumerableResource, expectedEnumerableString};
+			yield return new object[] {testeePagination, paginationResource, expectedPaginationString};
+		}
+	}
 }

--- a/HateoasNet.Framework.Tests/Formatting/HateoasFormatterTests.cs
+++ b/HateoasNet.Framework.Tests/Formatting/HateoasFormatterTests.cs
@@ -1,10 +1,4 @@
-﻿using HateoasNet.Abstractions;
-using HateoasNet.Framework.Formatting;
-using HateoasNet.Framework.Serialization;
-using HateoasNet.Resources;
-using HateoasNet.TestingObjects;
-using Moq;
-using System;
+﻿using System;
 using System.Collections;
 using System.IO;
 using System.Net;
@@ -12,134 +6,140 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
+using HateoasNet.Abstractions;
+using HateoasNet.Framework.Formatting;
+using HateoasNet.Framework.Serialization;
+using HateoasNet.Resources;
+using HateoasNet.TestingObjects;
+using Moq;
 using Xunit;
 
 namespace HateoasNet.Framework.Tests.Formatting
 {
-    public class HateoasMediaTypeFormatterTests : IDisposable
-    {
-        [Theory]
-        [FormattingData]
-        [Trait(nameof(HateoasMediaTypeFormatter), nameof(HateoasMediaTypeFormatter.WriteToStreamAsync))]
-        public void WriteToStreamAsync_ValidParameters_WriteExpectedText(object value, Resource resource, string text)
-        {
-            // arrange
-            const string supportedContentType = "application/json+hateoas";
-            var type = value.GetType();
-            var stream = new MemoryStream();
-            var testHttpContent = new TestHttpContent();
-            testHttpContent.Headers.ContentType = new MediaTypeHeaderValue(supportedContentType);
-            var mockResourceFactory = GenerateFullResourceFactoryMock(resource, value, type);
-            var sut = new HateoasMediaTypeFormatter(new Mock<IHateoasContext>().Object,
-                                                    mockResourceFactory.Object,
-                                                    new HateoasSerializer());
+	public class HateoasMediaTypeFormatterTests : IDisposable
+	{
+		/// <inheritdoc />
+		public void Dispose()
+		{
+			GC.SuppressFinalize(this);
+		}
 
-            // act
-            sut.WriteToStreamAsync(type, value, stream, testHttpContent, null, CancellationToken.None).Wait();
-            stream.Seek(0, SeekOrigin.Begin);
-            mockResourceFactory.Verify();
-            // reset position and read the stream to capture formatted string output
-            var actual = new StreamReader(stream).ReadToEnd();
+		[Theory]
+		[FormattingData]
+		[Trait(nameof(HateoasMediaTypeFormatter), nameof(HateoasMediaTypeFormatter.WriteToStreamAsync))]
+		public void WriteToStreamAsync_ValidParameters_WriteExpectedText(object value, Resource resource, string text)
+		{
+			// arrange
+			const string supportedContentType = "application/json+hateoas";
+			var type = value.GetType();
+			var stream = new MemoryStream();
+			var testHttpContent = new TestHttpContent();
+			testHttpContent.Headers.ContentType = new MediaTypeHeaderValue(supportedContentType);
+			var mockResourceFactory = GenerateFullResourceFactoryMock(resource, value, type);
+			var sut = new HateoasMediaTypeFormatter(new Mock<IHateoasContext>().Object,
+			                                        mockResourceFactory.Object,
+			                                        new HateoasSerializer());
 
-            // assert
-            Assert.Equal(text, actual);
-        }
+			// act
+			sut.WriteToStreamAsync(type, value, stream, testHttpContent, null, CancellationToken.None).Wait();
+			stream.Seek(0, SeekOrigin.Begin);
+			mockResourceFactory.Verify();
+			// reset position and read the stream to capture formatted string output
+			var actual = new StreamReader(stream).ReadToEnd();
 
-        [Fact]
-        [Trait(nameof(HateoasMediaTypeFormatter), nameof(HateoasMediaTypeFormatter.CanReadType))]
-        public void CanReadType_Always_ReturnsFalse()
-        {
-            // arrange
-            var sut = new HateoasMediaTypeFormatter(new Mock<IHateoasContext>().Object,
-                                                    new Mock<IResourceFactory>().Object,
-                                                    new Mock<IHateoasSerializer>().Object);
+			// assert
+			Assert.Equal(text, actual);
+		}
 
-            // act
-            var actual = sut.CanReadType(It.IsAny<Type>());
+		[Theory]
+		[InlineData(typeof(Testee), typeof(NestedTestee))]
+		[InlineData(typeof(NestedTestee), typeof(GenericTestee<Testee>))]
+		[InlineData(typeof(GenericTestee<Testee>), typeof(Testee))]
+		[Trait(nameof(HateoasMediaTypeFormatter), nameof(HateoasMediaTypeFormatter.CanWriteType))]
+		public void CanWriteType_WithTypeParameters_ReturnsExpectedBool(Type validType, Type invalidType)
+		{
+			// arrange
+			var hateoasContextMock = GenerateCanWriteHateoasContextMock(validType, invalidType);
+			var sut = new HateoasMediaTypeFormatter(hateoasContextMock.Object,
+			                                        new Mock<IResourceFactory>().Object,
+			                                        new Mock<IHateoasSerializer>().Object);
 
-            // assert
-            Assert.False(actual);
-        }
+			// act
+			var actualValid = sut.CanWriteType(validType);
+			var actualInvalid = sut.CanWriteType(invalidType);
 
-        [Theory]
-        [InlineData(typeof(Testee), typeof(NestedTestee))]
-        [InlineData(typeof(NestedTestee), typeof(GenericTestee<Testee>))]
-        [InlineData(typeof(GenericTestee<Testee>), typeof(Testee))]
-        [Trait(nameof(HateoasMediaTypeFormatter), nameof(HateoasMediaTypeFormatter.CanWriteType))]
-        public void CanWriteType_WithTypeParameters_ReturnsExpectedBool(Type validType, Type invalidType)
-        {
-            // arrange
-            var hateoasContextMock = GenerateCanWriteHateoasContextMock(validType, invalidType);
-            var sut = new HateoasMediaTypeFormatter(hateoasContextMock.Object,
-                                                    new Mock<IResourceFactory>().Object,
-                                                    new Mock<IHateoasSerializer>().Object);
+			// assert
+			Assert.True(actualValid);
+			Assert.False(actualInvalid);
+		}
 
-            // act
-            var actualValid = sut.CanWriteType(validType);
-            var actualInvalid = sut.CanWriteType(invalidType);
+		private Mock<IResourceFactory> GenerateFullResourceFactoryMock(Resource resource, object value, Type type)
+		{
+			var mockResourceFactory = new Mock<IResourceFactory>();
+			switch (value)
+			{
+				case IEnumerable enumerable:
+					mockResourceFactory.Setup(x => x.Create(enumerable, type))
+					                   .Returns(resource as EnumerableResource)
+					                   .Verifiable("unable to call Create with enumerable.");
+					break;
+				case IPagination pagination:
+					mockResourceFactory.Setup(x => x.Create(pagination, type))
+					                   .Returns(resource as PaginationResource)
+					                   .Verifiable("unable to call Create with pagination.");
+					break;
+				default:
+					mockResourceFactory.Setup(x => x.Create(value, type))
+					                   .Returns(resource as SingleResource)
+					                   .Verifiable("unable to call Create with object.");
+					break;
+			}
 
-            // assert
-            Assert.True(actualValid);
-            Assert.False(actualInvalid);
-        }
+			return mockResourceFactory;
+		}
 
-        private Mock<IResourceFactory> GenerateFullResourceFactoryMock(Resource resource, object value, Type type)
-        {
-            var mockResourceFactory = new Mock<IResourceFactory>();
-            switch (value)
-            {
-                case IEnumerable enumerable:
-                    mockResourceFactory.Setup(x => x.Create(enumerable, type))
-                                       .Returns(resource as EnumerableResource)
-                                       .Verifiable("unable to call Create with enumerable.");
-                    break;
-                case IPagination pagination:
-                    mockResourceFactory.Setup(x => x.Create(pagination, type))
-                                       .Returns(resource as PaginationResource)
-                                       .Verifiable("unable to call Create with pagination.");
-                    break;
-                default:
-                    mockResourceFactory.Setup(x => x.Create(value, type))
-                                       .Returns(resource as SingleResource)
-                                       .Verifiable("unable to call Create with object.");
-                    break;
-            }
+		private Mock<IHateoasContext> GenerateCanWriteHateoasContextMock(Type validType, Type invalidType)
+		{
+			var mockContext = new Mock<IHateoasContext>();
+			mockContext.Setup(x => x.HasResource(validType)).Returns(true);
+			mockContext.Setup(x => x.HasResource(invalidType)).Returns(false);
 
-            return mockResourceFactory;
-        }
+			return mockContext;
+		}
 
-        private Mock<IHateoasContext> GenerateCanWriteHateoasContextMock(Type validType, Type invalidType)
-        {
-            var mockContext = new Mock<IHateoasContext>();
-            mockContext.Setup(x => x.HasResource(validType)).Returns(true);
-            mockContext.Setup(x => x.HasResource(invalidType)).Returns(false);
+		[Fact]
+		[Trait(nameof(HateoasMediaTypeFormatter), nameof(HateoasMediaTypeFormatter.CanReadType))]
+		public void CanReadType_Always_ReturnsFalse()
+		{
+			// arrange
+			var sut = new HateoasMediaTypeFormatter(new Mock<IHateoasContext>().Object,
+			                                        new Mock<IResourceFactory>().Object,
+			                                        new Mock<IHateoasSerializer>().Object);
 
-            return mockContext;
-        }
+			// act
+			var actual = sut.CanReadType(It.IsAny<Type>());
 
-        /// <inheritdoc />
-        public void Dispose()
-        {
-            GC.SuppressFinalize(this);
-        }
-    }
+			// assert
+			Assert.False(actual);
+		}
+	}
 
     /// <summary>
-    /// Class implementing abstract HttpContent for test purposes.
+    ///   Class implementing abstract HttpContent for test purposes.
     /// </summary>
     public class TestHttpContent : HttpContent
-    {
-        /// <inheritdoc />
-        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
-        {
-            await Task.FromResult<object>(null);
-        }
+	{
+		/// <inheritdoc />
+		protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
+		{
+			await Task.FromResult<object>(null);
+		}
 
-        /// <inheritdoc />
-        protected override bool TryComputeLength(out long length)
-        {
-            length = 0;
-            return false;
-        }
-    }
+		/// <inheritdoc />
+		protected override bool TryComputeLength(out long length)
+		{
+			length = 0;
+			return false;
+		}
+	}
 }

--- a/HateoasNet.Framework.Tests/Serialization/HateoasSerializerTests.cs
+++ b/HateoasNet.Framework.Tests/Serialization/HateoasSerializerTests.cs
@@ -1,47 +1,47 @@
+using System;
 using HateoasNet.Abstractions;
 using HateoasNet.Framework.Serialization;
 using HateoasNet.Resources;
-using System;
 using Xunit;
 
 namespace HateoasNet.Framework.Tests.Serialization
 {
-    public class HateoasSerializerTests : IDisposable
-    {
-        [Theory]
-        [SerializationData]
-        [Trait(nameof(IHateoasSerializer), nameof(IHateoasSerializer.SerializeResource))]
-        public void SerializeResource_WithValidResource_ReturnsExpectedString(Resource resource, string expectedOutput)
-        {
-            // arrange
-            var sut = new HateoasSerializer();
+	public class HateoasSerializerTests : IDisposable
+	{
+		/// <inheritdoc />
+		public void Dispose()
+		{
+			GC.SuppressFinalize(this);
+		}
 
-            // act
-            var actual = sut.SerializeResource(resource);
+		[Theory]
+		[SerializationData]
+		[Trait(nameof(IHateoasSerializer), nameof(IHateoasSerializer.SerializeResource))]
+		public void SerializeResource_WithValidResource_ReturnsExpectedString(Resource resource, string expectedOutput)
+		{
+			// arrange
+			var sut = new HateoasSerializer();
 
-            // assert
-            Assert.Equal(expectedOutput, actual);
-        }
+			// act
+			var actual = sut.SerializeResource(resource);
 
-        [Fact]
-        [Trait(nameof(IHateoasSerializer), nameof(IHateoasSerializer.SerializeResource))]
-        [Trait(nameof(IHateoasSerializer), "Exceptions")]
-        public void SerializeResource_WithNull_Throws_ArgumentNullException()
-        {
-            // arrange
-            var sut = new HateoasSerializer();
-            const string parameterName = "resource";
+			// assert
+			Assert.Equal(expectedOutput, actual);
+		}
 
-            // act
-            Action actual = () => sut.SerializeResource(null);
+		[Fact]
+		[Trait(nameof(IHateoasSerializer), nameof(IHateoasSerializer.SerializeResource))]
+		[Trait(nameof(IHateoasSerializer), "Exceptions")]
+		public void SerializeResource_WithNull_Throws_ArgumentNullException()
+		{
+			// arrange
+			var sut = new HateoasSerializer();
+			const string parameterName = "resource";
 
-            Assert.Throws<ArgumentNullException>(parameterName, actual);
-        }
+			// act
+			Action actual = () => sut.SerializeResource(null);
 
-        /// <inheritdoc />
-        public void Dispose()
-        {
-            GC.SuppressFinalize(this);
-        }
-    }
+			Assert.Throws<ArgumentNullException>(parameterName, actual);
+		}
+	}
 }

--- a/HateoasNet.Framework.Tests/Serialization/SerializationDataAttribute.cs
+++ b/HateoasNet.Framework.Tests/Serialization/SerializationDataAttribute.cs
@@ -1,62 +1,62 @@
-using HateoasNet.Resources;
-using HateoasNet.TestingObjects;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using HateoasNet.Resources;
+using HateoasNet.TestingObjects;
 using Xunit.Sdk;
 
 namespace HateoasNet.Framework.Tests.Serialization
 {
-    public class SerializationData : DataAttribute
-    {
-        public override IEnumerable<object[]> GetData(MethodInfo testMethod)
-        {
-            // Guid and DateTime values shared for serialization test
-            var sharedGuid = Guid.Parse("96685bc4-dcb7-4b22-90cc-ca83baff8186");
-            var sharedDateTime = DateTime.Parse("Fri, 1 May 2020 00:00:00Z");
+	public class SerializationData : DataAttribute
+	{
+		public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+		{
+			// Guid and DateTime values shared for serialization test
+			var sharedGuid = Guid.Parse("96685bc4-dcb7-4b22-90cc-ca83baff8186");
+			var sharedDateTime = DateTime.Parse("Fri, 1 May 2020 00:00:00Z");
 
-            // dummies
-            var emptyLink = new ResourceLink("", "", "");
-            var testee = new Testee { Id = sharedGuid, CreatedDate = sharedDateTime };
-            var nestedTestee = new NestedTestee
-            {
-                Id = sharedGuid,
-                CreatedDate = sharedDateTime,
-                Nested = testee,
-                Collection = new List<Testee> { testee }
-            };
-            var genericTestee = new GenericTestee<Testee>
-            {
-                Nested = nestedTestee,
-                Id = sharedGuid,
-                CreatedDate = sharedDateTime,
-                Collection = new List<Testee> { testee, nestedTestee }
-            };
-            var testees = new List<Testee> { testee, nestedTestee, genericTestee };
+			// dummies
+			var emptyLink = new ResourceLink("", "", "");
+			var testee = new Testee {Id = sharedGuid, CreatedDate = sharedDateTime};
+			var nestedTestee = new NestedTestee
+			{
+				Id = sharedGuid,
+				CreatedDate = sharedDateTime,
+				Nested = testee,
+				Collection = new List<Testee> {testee}
+			};
+			var genericTestee = new GenericTestee<Testee>
+			{
+				Nested = nestedTestee,
+				Id = sharedGuid,
+				CreatedDate = sharedDateTime,
+				Collection = new List<Testee> {testee, nestedTestee}
+			};
+			var testees = new List<Testee> {testee, nestedTestee, genericTestee};
 
-            // resources
-            var resources = testees.Select(x =>
-            {
-                var resource = new SingleResource(x);
-                resource.Links.Add(emptyLink);
-                return resource;
-            }).ToList();
+			// resources
+			var resources = testees.Select(x =>
+			{
+				var resource = new SingleResource(x);
+				resource.Links.Add(emptyLink);
+				return resource;
+			}).ToList();
 
-            var enumerableResource = new EnumerableResource(resources);
-            enumerableResource.Links.Add(emptyLink);
-            var paginationResource = new PaginationResource(resources, resources.Count(), 5, 1);
-            paginationResource.Links.Add(emptyLink);
+			var enumerableResource = new EnumerableResource(resources);
+			enumerableResource.Links.Add(emptyLink);
+			var paginationResource = new PaginationResource(resources, resources.Count(), 5, 1);
+			paginationResource.Links.Add(emptyLink);
 
-            // expectedOutputs
-            var expectedSingleString = File.ReadAllText(Path.Combine("Serialization", "SingleResource.json"));
-            var expectedEnumerableString = File.ReadAllText(Path.Combine("Serialization", "EnumerableResource.json"));
-            var expectedPaginationString = File.ReadAllText(Path.Combine("Serialization", "PaginationResource.json"));
+			// expectedOutputs
+			var expectedSingleString = File.ReadAllText(Path.Combine("Serialization", "SingleResource.json"));
+			var expectedEnumerableString = File.ReadAllText(Path.Combine("Serialization", "EnumerableResource.json"));
+			var expectedPaginationString = File.ReadAllText(Path.Combine("Serialization", "PaginationResource.json"));
 
-            yield return new object[] { resources.First(), expectedSingleString };
-            yield return new object[] { enumerableResource, expectedEnumerableString };
-            yield return new object[] { paginationResource, expectedPaginationString };
-        }
-    }
+			yield return new object[] {resources.First(), expectedSingleString};
+			yield return new object[] {enumerableResource, expectedEnumerableString};
+			yield return new object[] {paginationResource, expectedPaginationString};
+		}
+	}
 }

--- a/HateoasNet.Framework/DependencyInjection/HateoasExtensions.cs
+++ b/HateoasNet.Framework/DependencyInjection/HateoasExtensions.cs
@@ -1,11 +1,11 @@
-﻿using HateoasNet.Abstractions;
+﻿using System;
+using HateoasNet.Abstractions;
 using HateoasNet.Configurations;
-using System;
 
 namespace HateoasNet.Framework.DependencyInjection
 {
-    public static class HateoasExtensions
-    {
+	public static class HateoasExtensions
+	{
         /// <summary>
         ///   Configure Hateoas Resource mapping in .Net Framework (Full) Web Api
         /// </summary>
@@ -13,10 +13,10 @@ namespace HateoasNet.Framework.DependencyInjection
         /// <returns></returns>
         /// <exception cref="ArgumentNullException"></exception>
         public static IHateoasContext ConfigureHateoas(Func<IHateoasContext, IHateoasContext> configuration)
-        {
-            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
+		{
+			if (configuration == null) throw new ArgumentNullException(nameof(configuration));
 
-            return configuration(new HateoasContext());
-        }
-    }
+			return configuration(new HateoasContext());
+		}
+	}
 }

--- a/HateoasNet.Framework/Factories/ResourceLinkFactory.cs
+++ b/HateoasNet.Framework/Factories/ResourceLinkFactory.cs
@@ -114,7 +114,7 @@ namespace HateoasNet.Framework.Factories
 
             var replacedTemplate = template;
             const string fromRouteVariablePattern = @"\{(.*?)\}";
-            const string variableIdentifierPattern = @"\w(\w|\d|_)*";
+            const string variableIdentifierPattern = @"\w(\w|\d|testee)*";
 
             foreach (Match match in Regex.Matches(replacedTemplate, fromRouteVariablePattern))
             {

--- a/HateoasNet.Framework/Factories/ResourceLinkFactory.cs
+++ b/HateoasNet.Framework/Factories/ResourceLinkFactory.cs
@@ -1,6 +1,4 @@
-﻿using HateoasNet.Abstractions;
-using HateoasNet.Resources;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -10,49 +8,51 @@ using System.Web;
 using System.Web.Http;
 using System.Web.Http.Controllers;
 using System.Web.Routing;
+using HateoasNet.Abstractions;
+using HateoasNet.Resources;
 
 namespace HateoasNet.Framework.Factories
 {
-    /// <inheritdoc cref="IResourceLinkFactory" />
-    public sealed class ResourceLinkFactory : IResourceLinkFactory
-    {
-        private Dictionary<RouteAttribute, HttpActionDescriptor> _routeActionDescriptors;
-        private readonly RouteAttribute _dummyRouteAttributeInCaseNotFound = new RouteAttribute("unable-to-find-route");
+	/// <inheritdoc cref="IResourceLinkFactory" />
+	public sealed class ResourceLinkFactory : IResourceLinkFactory
+	{
+		private readonly RouteAttribute _dummyRouteAttributeInCaseNotFound = new RouteAttribute("unable-to-find-route");
+		private Dictionary<RouteAttribute, HttpActionDescriptor> _routeActionDescriptors;
 
         /// <summary>
-        /// 	Constructor for testing purposes.
+        ///   Constructor for testing purposes.
         /// </summary>
         /// <param name="actionDescriptors"></param>
         public ResourceLinkFactory(IEnumerable<HttpActionDescriptor> actionDescriptors)
-        {
-            _routeActionDescriptors = actionDescriptors.ToDictionary(GetRouteAttribute);
-        }
+		{
+			_routeActionDescriptors = actionDescriptors.ToDictionary(GetRouteAttribute);
+		}
 
-        public ResourceLinkFactory()
-        {
-        }
+		public ResourceLinkFactory()
+		{
+		}
 
-        internal Dictionary<RouteAttribute, HttpActionDescriptor> BuildRouteActionDescriptors()
-        {
-            var actionDescriptors = RouteTable
-                                    .Routes
-                                    .OfType<Route>()
-                                    .Select(route => route.DataTokens.Values.OfType<HttpActionDescriptor[]>()
-                                                          .FirstOrDefault()?.First()).Where(x => x != null);
+		public ResourceLink Create(string rel, IDictionary<string, object> routeValues)
+		{
+			if (string.IsNullOrWhiteSpace(rel)) throw new ArgumentNullException(nameof(rel));
 
-            return actionDescriptors.ToDictionary(GetRouteAttribute);
-        }
+			_routeActionDescriptors ??= BuildRouteActionDescriptors();
 
-        public ResourceLink Create(string rel, IDictionary<string, object> routeValues)
-        {
-            if (string.IsNullOrWhiteSpace(rel)) throw new ArgumentNullException(nameof(rel));
+			var href = GetRouteUrl(rel, routeValues);
+			var method = GetRouteMethod(rel);
+			return new ResourceLink(rel, href, method);
+		}
 
-            _routeActionDescriptors ??= BuildRouteActionDescriptors();
+		internal Dictionary<RouteAttribute, HttpActionDescriptor> BuildRouteActionDescriptors()
+		{
+			var actionDescriptors = RouteTable
+			                        .Routes
+			                        .OfType<Route>()
+			                        .Select(route => route.DataTokens.Values.OfType<HttpActionDescriptor[]>()
+			                                              .FirstOrDefault()?.First()).Where(x => x != null);
 
-            var href = GetRouteUrl(rel, routeValues);
-            var method = GetRouteMethod(rel);
-            return new ResourceLink(rel, href, method);
-        }
+			return actionDescriptors.ToDictionary(GetRouteAttribute);
+		}
 
         /// <summary>
         ///   Builds an url <see langword="string" /> with the <paramref name="routeName" /> and <paramref name="routeValues" />.
@@ -61,31 +61,31 @@ namespace HateoasNet.Framework.Factories
         /// <param name="routeValues">Route dictionary to look for parameters and query strings.</param>
         /// <returns>Generated Url <see langword="string" /> value.</returns>
         internal string GetRouteUrl(string routeName, IDictionary<string, object> routeValues)
-        {
-            if (string.IsNullOrWhiteSpace(routeName)) throw new ArgumentNullException(nameof(routeName));
-            if (HttpContext.Current.Request == null) throw new NullReferenceException(nameof(HttpContext.Current.Request));
+		{
+			if (string.IsNullOrWhiteSpace(routeName)) throw new ArgumentNullException(nameof(routeName));
+			if (HttpContext.Current.Request == null) throw new NullReferenceException(nameof(HttpContext.Current.Request));
 
-            var (routeAttribute, descriptor) = _routeActionDescriptors.Where(pair => pair.Key.Name == routeName)
-                                                                      .Select(x => (x.Key, x.Value)).First();
+			var (routeAttribute, descriptor) = _routeActionDescriptors.Where(pair => pair.Key.Name == routeName)
+			                                                          .Select(x => (x.Key, x.Value)).First();
 
-            if (descriptor == null) throw new ArgumentNullException(nameof(descriptor));
+			if (descriptor == null) throw new ArgumentNullException(nameof(descriptor));
 
-            // set resource name from controller
-            var controllerDescriptor = descriptor.ControllerDescriptor;
-            var routePrefixAttribute = controllerDescriptor.GetCustomAttributes<RoutePrefixAttribute>().FirstOrDefault();
-            var resourceName = routePrefixAttribute != null
-              ? routePrefixAttribute.Prefix
-              : controllerDescriptor.ControllerName;
+			// set resource name from controller
+			var controllerDescriptor = descriptor.ControllerDescriptor;
+			var routePrefixAttribute = controllerDescriptor.GetCustomAttributes<RoutePrefixAttribute>().FirstOrDefault();
+			var resourceName = routePrefixAttribute != null
+				? routePrefixAttribute.Prefix
+				: controllerDescriptor.ControllerName;
 
-            var request = HttpContext.Current.Request;
-            var segments = $"{request.Url.Authority}{request.ApplicationPath}/{resourceName}".Replace("//", "/");
-            var resourceUrl = $"{request.Url.Scheme}://{segments}";
+			var request = HttpContext.Current.Request;
+			var segments = $"{request.Url.Authority}{request.ApplicationPath}/{resourceName}".Replace("//", "/");
+			var resourceUrl = $"{request.Url.Scheme}://{segments}";
 
-            resourceUrl = HandleRouteTemplate(resourceUrl, routeAttribute.Template, routeValues);
+			resourceUrl = HandleRouteTemplate(resourceUrl, routeAttribute.Template, routeValues);
 
-            var parameters = descriptor.GetParameters().Select(x => x.ParameterName);
-            return HandleQueryStrings(resourceUrl, routeAttribute.Template, parameters, routeValues);
-        }
+			var parameters = descriptor.GetParameters().Select(x => x.ParameterName);
+			return HandleQueryStrings(resourceUrl, routeAttribute.Template, parameters, routeValues);
+		}
 
         /// <summary>
         ///   Find the <see langword="string" /> value of HTTP method of a route with given <paramref name="routeName" />.
@@ -93,76 +93,76 @@ namespace HateoasNet.Framework.Factories
         /// <param name="routeName">The wanted endpoint route name to find.</param>
         /// <returns><see langword="string" />value representing HTTP method.</returns>
         internal string GetRouteMethod(string routeName)
-        {
-            if (string.IsNullOrWhiteSpace(routeName)) throw new ArgumentNullException(nameof(routeName));
+		{
+			if (string.IsNullOrWhiteSpace(routeName)) throw new ArgumentNullException(nameof(routeName));
 
-            var descriptor = _routeActionDescriptors.Where(pair => pair.Key.Name == routeName)
-                                                    .Select(pair => pair.Value)
-                                                    .Single();
+			var descriptor = _routeActionDescriptors.Where(pair => pair.Key.Name == routeName)
+			                                        .Select(pair => pair.Value)
+			                                        .Single();
 
-            var httpMethod = descriptor.SupportedHttpMethods.FirstOrDefault() ??
-                             throw new InvalidOperationException(Error<HttpMethod>());
+			var httpMethod = descriptor.SupportedHttpMethods.FirstOrDefault() ??
+			                 throw new InvalidOperationException(Error<HttpMethod>());
 
-            return httpMethod.Method;
-        }
+			return httpMethod.Method;
+		}
 
-        internal string HandleRouteTemplate(string resourceUrl, string template, IDictionary<string, object> routeValues)
-        {
-            if (string.IsNullOrWhiteSpace(resourceUrl)) throw new ArgumentNullException(nameof(resourceUrl));
-            if (string.IsNullOrWhiteSpace(template)) return resourceUrl;
-            if (routeValues == null) return $"{resourceUrl}/{template}";
+		internal string HandleRouteTemplate(string resourceUrl, string template, IDictionary<string, object> routeValues)
+		{
+			if (string.IsNullOrWhiteSpace(resourceUrl)) throw new ArgumentNullException(nameof(resourceUrl));
+			if (string.IsNullOrWhiteSpace(template)) return resourceUrl;
+			if (routeValues == null) return $"{resourceUrl}/{template}";
 
-            var replacedTemplate = template;
-            const string fromRouteVariablePattern = @"\{(.*?)\}";
-            const string variableIdentifierPattern = @"\w(\w|\d|testee)*";
+			var replacedTemplate = template;
+			const string fromRouteVariablePattern = @"\{(.*?)\}";
+			const string variableIdentifierPattern = @"\w(\w|\d|testee)*";
 
-            foreach (Match match in Regex.Matches(replacedTemplate, fromRouteVariablePattern))
-            {
-                var key = match.Value.Replace("{", "").Replace("}", "");
-                if (!routeValues.TryGetValue(key, out var replacement))
-                {
-                    key = Regex.Matches(match.Value, variableIdentifierPattern)[0].Value;
-                    if (!routeValues.TryGetValue(key, out replacement))
-                        throw new InvalidOperationException($"Unable to find key '{key}' from dictionary of route values.");
-                }
+			foreach (Match match in Regex.Matches(replacedTemplate, fromRouteVariablePattern))
+			{
+				var key = match.Value.Replace("{", "").Replace("}", "");
+				if (!routeValues.TryGetValue(key, out var replacement))
+				{
+					key = Regex.Matches(match.Value, variableIdentifierPattern)[0].Value;
+					if (!routeValues.TryGetValue(key, out replacement))
+						throw new InvalidOperationException($"Unable to find key '{key}' from dictionary of route values.");
+				}
 
-                replacedTemplate = replacedTemplate.Replace(match.Value, replacement?.ToString());
-            }
+				replacedTemplate = replacedTemplate.Replace(match.Value, replacement?.ToString());
+			}
 
-            return $"{resourceUrl}/{replacedTemplate}";
-        }
+			return $"{resourceUrl}/{replacedTemplate}";
+		}
 
-        internal string HandleQueryStrings(string resourceUrl, string template, IEnumerable<string> parameterNames,
-                                           IDictionary<string, object> routeValues)
-        {
-            if (resourceUrl == null) throw new ArgumentNullException(nameof(resourceUrl));
-            if (routeValues == null) return resourceUrl;
+		internal string HandleQueryStrings(string resourceUrl, string template, IEnumerable<string> parameterNames,
+		                                   IDictionary<string, object> routeValues)
+		{
+			if (resourceUrl == null) throw new ArgumentNullException(nameof(resourceUrl));
+			if (routeValues == null) return resourceUrl;
 
-            if (parameterNames == null) throw new ArgumentNullException(nameof(parameterNames));
-            if (template == null) throw new ArgumentNullException(nameof(template));
+			if (parameterNames == null) throw new ArgumentNullException(nameof(parameterNames));
+			if (template == null) throw new ArgumentNullException(nameof(template));
 
-            return parameterNames
-                   .Where(routeValues.ContainsKey)
-                   .Where(name => !template.Contains($"{{{name}"))
-                   .OrderBy(p => p)
-                   .Aggregate(resourceUrl, (query, parameterName) =>
-                   {
-                       var symbol = (query == resourceUrl ? "?" : "&");
-                       return $"{query}{symbol}{parameterName}={routeValues[parameterName]}";
-                   });
-        }
+			return parameterNames
+			       .Where(routeValues.ContainsKey)
+			       .Where(name => !template.Contains($"{{{name}"))
+			       .OrderBy(p => p)
+			       .Aggregate(resourceUrl, (query, parameterName) =>
+			       {
+				       var symbol = query == resourceUrl ? "?" : "&";
+				       return $"{query}{symbol}{parameterName}={routeValues[parameterName]}";
+			       });
+		}
 
-        internal RouteAttribute GetRouteAttribute(HttpActionDescriptor descriptor)
-        {
-            var methodInfo = descriptor.GetType().GetProperty("MethodInfo")?.GetValue(descriptor) as MethodInfo;
+		internal RouteAttribute GetRouteAttribute(HttpActionDescriptor descriptor)
+		{
+			var methodInfo = descriptor.GetType().GetProperty("MethodInfo")?.GetValue(descriptor) as MethodInfo;
 
-            return methodInfo?.GetCustomAttributes(true).OfType<RouteAttribute>().FirstOrDefault()
-                   ?? _dummyRouteAttributeInCaseNotFound;
-        }
+			return methodInfo?.GetCustomAttributes(true).OfType<RouteAttribute>().FirstOrDefault()
+			       ?? _dummyRouteAttributeInCaseNotFound;
+		}
 
-        private string Error<T>()
-        {
-            return $"Unable to get '{typeof(T).Name}' needed to create the link.";
-        }
-    }
+		private string Error<T>()
+		{
+			return $"Unable to get '{typeof(T).Name}' needed to create the link.";
+		}
+	}
 }

--- a/HateoasNet.Framework/Formatting/HateoasMediaTypeFormatter.cs
+++ b/HateoasNet.Framework/Formatting/HateoasMediaTypeFormatter.cs
@@ -1,6 +1,4 @@
-﻿using HateoasNet.Abstractions;
-using HateoasNet.Resources;
-using System;
+﻿using System;
 using System.Collections;
 using System.IO;
 using System.Linq;
@@ -11,68 +9,70 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using HateoasNet.Abstractions;
+using HateoasNet.Resources;
 
 namespace HateoasNet.Framework.Formatting
 {
-    public class HateoasMediaTypeFormatter : MediaTypeFormatter
-    {
-        private readonly IHateoasContext _hateoasContext;
-        private readonly IHateoasSerializer _hateoasSerializer;
-        private readonly IResourceFactory _resourceFactory;
+	public class HateoasMediaTypeFormatter : MediaTypeFormatter
+	{
+		private readonly IHateoasContext _hateoasContext;
+		private readonly IHateoasSerializer _hateoasSerializer;
+		private readonly IResourceFactory _resourceFactory;
 
-        public HateoasMediaTypeFormatter(IHateoasContext hateoasContext,
-                                         IResourceFactory resourceFactory,
-                                         IHateoasSerializer hateoasSerializer)
-        {
-            _hateoasContext = hateoasContext;
-            _resourceFactory = resourceFactory;
-            _hateoasSerializer = hateoasSerializer;
+		public HateoasMediaTypeFormatter(IHateoasContext hateoasContext,
+		                                 IResourceFactory resourceFactory,
+		                                 IHateoasSerializer hateoasSerializer)
+		{
+			_hateoasContext = hateoasContext;
+			_resourceFactory = resourceFactory;
+			_hateoasSerializer = hateoasSerializer;
 
-            SupportedMediaTypes.Add(new MediaTypeHeaderValue("application/json+hateoas"));
+			SupportedMediaTypes.Add(new MediaTypeHeaderValue("application/json+hateoas"));
 
-            SupportedEncodings.Add(new UTF8Encoding(false));
-            SupportedEncodings.Add(Encoding.GetEncoding("iso-8859-1"));
-        }
+			SupportedEncodings.Add(new UTF8Encoding(false));
+			SupportedEncodings.Add(Encoding.GetEncoding("iso-8859-1"));
+		}
 
-        public override bool CanReadType(Type type)
-        {
-            return false;
-        }
+		public override bool CanReadType(Type type)
+		{
+			return false;
+		}
 
-        public override bool CanWriteType(Type type)
-        {
-            return _hateoasContext.HasResource(type);
-        }
+		public override bool CanWriteType(Type type)
+		{
+			return _hateoasContext.HasResource(type);
+		}
 
-        public override async Task WriteToStreamAsync(Type type,
-                                                      object value,
-                                                      Stream writeStream,
-                                                      HttpContent content,
-                                                      TransportContext transportContext,
-                                                      CancellationToken cancellationToken)
-        {
-            var notSupportedMessage =
-                $"The request using '{nameof(HateoasMediaTypeFormatter)}' does not have required Content-Type header '{SupportedMediaTypes.Last()}'.";
+		public override async Task WriteToStreamAsync(Type type,
+		                                              object value,
+		                                              Stream writeStream,
+		                                              HttpContent content,
+		                                              TransportContext transportContext,
+		                                              CancellationToken cancellationToken)
+		{
+			var notSupportedMessage =
+				$"The request using '{nameof(HateoasMediaTypeFormatter)}' does not have required Content-Type header '{SupportedMediaTypes.Last()}'.";
 
-            if (!CheckSupportedContent(content)) throw new NotSupportedException(notSupportedMessage);
+			if (!CheckSupportedContent(content)) throw new NotSupportedException(notSupportedMessage);
 
-            Resource resource = value switch
-            {
-                IPagination pagination => _resourceFactory.Create(pagination, type),
-                IEnumerable enumerable => _resourceFactory.Create(enumerable, type),
-                _ => _resourceFactory.Create(value, type)
-            };
-            var effectiveEncoding = SelectCharacterEncoding(content.Headers);
-            var formattedResponse = _hateoasSerializer.SerializeResource(resource);
-            var responseBytes = effectiveEncoding.GetBytes(formattedResponse.ToCharArray());
-            await writeStream.WriteAsync(responseBytes, 0, responseBytes.Length, cancellationToken);
-        }
+			Resource resource = value switch
+			{
+				IPagination pagination => _resourceFactory.Create(pagination, type),
+				IEnumerable enumerable => _resourceFactory.Create(enumerable, type),
+				_ => _resourceFactory.Create(value, type)
+			};
+			var effectiveEncoding = SelectCharacterEncoding(content.Headers);
+			var formattedResponse = _hateoasSerializer.SerializeResource(resource);
+			var responseBytes = effectiveEncoding.GetBytes(formattedResponse.ToCharArray());
+			await writeStream.WriteAsync(responseBytes, 0, responseBytes.Length, cancellationToken);
+		}
 
-        private bool CheckSupportedContent(HttpContent content)
-        {
-            var supportedType = SupportedMediaTypes.Last().ToString();
-            var contentType = content.Headers.ContentType.ToString();
-            return contentType.Contains(supportedType);
-        }
-    }
+		private bool CheckSupportedContent(HttpContent content)
+		{
+			var supportedType = SupportedMediaTypes.Last().ToString();
+			var contentType = content.Headers.ContentType.ToString();
+			return contentType.Contains(supportedType);
+		}
+	}
 }

--- a/HateoasNet.Framework/HateoasNet.Framework.nuspec
+++ b/HateoasNet.Framework/HateoasNet.Framework.nuspec
@@ -1,21 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package >
+  
   <metadata>
-    <id>$id$</id>
-    <version>$version$-alpha</version>
-    <title>$title$</title>
-    <authors>$author$</authors>
-    <owners>$author$</owners>
+    
+    <id>HateoasNet.Framework</id>
+    <version>$version$</version>
+    <title>HateoasNet Framework Library</title>
+    <authors>Icaro Torres</authors>
+    <owners>icarotorres</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/IcaroTorres/HateoasNet/tree/master/HateoasNet.Framework</projectUrl>
-    <repository url="https://github.com/IcaroTorres/HateoasNet.git" type="git" branch="master"/>
-    <description>$description$</description>
-    <summary>$description$</summary>
+    <repository url="https://github.com/IcaroTorres/HateoasNet.git" type="git" branch="master" commit="b8656f58a5eac281cb8e1e7814d98ddf88d9a956"/>
+    <description>Class Library targeting Net Framework 4.72 for ease output formatting .Net Web Api response into Json with HATEOAS.</description>
     <packageTypes><packageType name="Dependency" /></packageTypes>
     <releaseNotes>
       HateoasNet.Framework Class library. Targeting Net Framework for platform-specific features of HateoasNet.
-      
+
       Features:
     
       Formatting, Serialization and Url platform-specific implementations targeting .Net Framework version 4.7.2.
@@ -24,10 +25,21 @@
 
       visit project repo to contribute: https://github.com/icarotorres/HateoasNet.git
     </releaseNotes>
-    <copyright>Copyright 2020</copyright>
+    <copyright>Copyright ©2020 Icaro Torres</copyright>
     <tags>json hateoas-response api-rest hateoas-net hateoas-formatting</tags>
-    <dependencies>      
-      <group targetFramework=".NETFramework4.7.2" >
+
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="System" targetFramework="net472" />
+      <frameworkAssembly assemblyName="System.Core" targetFramework="net472" />
+      <frameworkAssembly assemblyName="System.Data" targetFramework="net472" />
+      <frameworkAssembly assemblyName="System.Net.Http" targetFramework="net472" />
+      <frameworkAssembly assemblyName="System.Web" targetFramework="net472" />
+      <frameworkAssembly assemblyName="System.Xml" targetFramework="net472" />
+    </frameworkAssemblies>
+
+    <dependencies>
+      <group targetFramework="net472">
+        <dependency id="HateoasNet" version="1.0.0-alpha-0" />
         <dependency id="Microsoft.AspNet.WebApi.Client" version="5.2.7" />
         <dependency id="Microsoft.AspNet.WebApi.Core" version="5.2.7" />
         <dependency id="Microsoft.AspNet.WebApi.WebHost" version="5.2.7" />
@@ -35,5 +47,11 @@
         <dependency id="Newtonsoft.Json" version="12.0.3" />
       </group>
     </dependencies>
+    
   </metadata>
+  
+  <files>
+    <file src="bin\Release\*" target="lib\net472" />
+  </files>
+  
 </package>

--- a/HateoasNet.Framework/Properties/AssemblyInfo.cs
+++ b/HateoasNet.Framework/Properties/AssemblyInfo.cs
@@ -6,7 +6,8 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("HateoasNet.Framework")]
-[assembly: AssemblyDescription("Class Library targeting Net Framework 4.72 for ease output formatting .Net Web Api response into Json with HATEOAS.")]
+[assembly:
+	AssemblyDescription("Class Library targeting Net Framework 4.72 for ease output formatting .Net Web Api response into Json with HATEOAS.")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Icaro Torres")]
 [assembly: AssemblyProduct("HateoasNet.Framework")]

--- a/HateoasNet.Framework/Serialization/HateoasSerializer.cs
+++ b/HateoasNet.Framework/Serialization/HateoasSerializer.cs
@@ -1,34 +1,34 @@
-﻿using HateoasNet.Abstractions;
+﻿using System;
+using HateoasNet.Abstractions;
 using HateoasNet.Resources;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
-using System;
 
 namespace HateoasNet.Framework.Serialization
 {
-    /// <inheritdoc cref="IHateoasSerializer"/>
+    /// <inheritdoc cref="IHateoasSerializer" />
     public class HateoasSerializer : IHateoasSerializer
-    {
+	{
+		private readonly JsonSerializerSettings _settings;
+
         /// <summary>
-        ///   Constructor accepting an optional <see cref="JsonSerializerSettings"/> as <paramref name="settings" />.
+        ///   Constructor accepting an optional <see cref="JsonSerializerSettings" /> as <paramref name="settings" />.
         /// </summary>
         /// <param name="settings">Optional settings for custom output serialization.</param>
         public HateoasSerializer(JsonSerializerSettings settings = null)
-        {
-            _settings = settings ?? new JsonSerializerSettings
-            {
-                NullValueHandling = NullValueHandling.Ignore,
-                ContractResolver = new CamelCasePropertyNamesContractResolver()
-            };
-        }
+		{
+			_settings = settings ?? new JsonSerializerSettings
+			{
+				NullValueHandling = NullValueHandling.Ignore,
+				ContractResolver = new CamelCasePropertyNamesContractResolver()
+			};
+		}
 
-        private readonly JsonSerializerSettings _settings;
+		public string SerializeResource(Resource resource)
+		{
+			if (resource == null) throw new ArgumentNullException(nameof(resource));
 
-        public string SerializeResource(Resource resource)
-        {
-            if (resource == null) throw new ArgumentNullException(nameof(resource));
-
-            return JsonConvert.SerializeObject(resource, resource.GetType(), _settings);
-        }
-    }
+			return JsonConvert.SerializeObject(resource, resource.GetType(), _settings);
+		}
+	}
 }

--- a/HateoasNet.Tests/Configurations/HateoasContextTests.cs
+++ b/HateoasNet.Tests/Configurations/HateoasContextTests.cs
@@ -1,216 +1,216 @@
-﻿using HateoasNet.Abstractions;
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using HateoasNet.Abstractions;
 using HateoasNet.Configurations;
 using HateoasNet.TestingObjects;
 using HateoasNet.Tests.TestHelpers;
-using System;
-using System.Collections.Generic;
-using System.Reflection;
 using Xunit;
 
 namespace HateoasNet.Tests.Configurations
 {
-    public class HateoasContextTests : IDisposable
-    {
-        public HateoasContextTests()
-        {
-            _sut = new HateoasContext();
-        }
+	public class HateoasContextTests : IDisposable
+	{
+		public HateoasContextTests()
+		{
+			_sut = new HateoasContext();
+		}
 
-        private readonly IHateoasContext _sut;
+		/// <inheritdoc />
+		public void Dispose()
+		{
+			GC.SuppressFinalize(this);
+		}
 
-        [Fact]
-        [Trait(nameof(IHateoasContext), "New")]
-        public void New_WithOutParameters_HateoasContext()
-        {
-            Assert.IsAssignableFrom<IHateoasContext>(_sut);
-            Assert.IsType<HateoasContext>(_sut);
-        }
+		private readonly IHateoasContext _sut;
 
-        [Theory]
-        [ConfigureData]
-        [Trait(nameof(IHateoasContext), nameof(IHateoasContext.HasResource))]
-        public void HasResource_WithInvalidType_ReturnFalse(object invalid)
-        {
-            // act
-            var actual = _sut.HasResource(invalid.GetType());
+		[Theory]
+		[ConfigureData]
+		[Trait(nameof(IHateoasContext), nameof(IHateoasContext.HasResource))]
+		public void HasResource_WithInvalidType_ReturnFalse(object invalid)
+		{
+			// act
+			var actual = _sut.HasResource(invalid.GetType());
 
-            // assert
-            Assert.False(actual);
-        }
+			// assert
+			Assert.False(actual);
+		}
 
-        [Theory]
-        [ConfigureData]
-        [Trait(nameof(IHateoasContext), nameof(IHateoasContext.HasResource))]
-        public void HasResource_WithValidType_ReturnTrue<T>(T valid) where T : class
-        {
-            // arrange
-            var hateoasContext = _sut.Configure<T>(resource => { });
+		[Theory]
+		[ConfigureData]
+		[Trait(nameof(IHateoasContext), nameof(IHateoasContext.HasResource))]
+		public void HasResource_WithValidType_ReturnTrue<T>(T valid) where T : class
+		{
+			// arrange
+			var hateoasContext = _sut.Configure<T>(resource => { });
 
-            // act
-            var actual = _sut.HasResource(valid.GetType());
+			// act
+			var actual = _sut.HasResource(valid.GetType());
 
-            // assert
-            Assert.Same(_sut, hateoasContext);
-            Assert.True(actual);
-        }
+			// assert
+			Assert.Same(_sut, hateoasContext);
+			Assert.True(actual);
+		}
 
-        [Theory]
-        [ConfigureData]
-        [Trait(nameof(IHateoasContext), nameof(HateoasContext.GetOrInsert))]
-        [Trait(nameof(IHateoasContext), nameof(IHateoasContext.HasResource))]
-        public void GetOrInsert_WithClassType_ReturnIHateoasResource<T>(T instance) where T : class
-        {
-            // act
-            var interfaceHateoasResource = (_sut as HateoasContext)?.GetOrInsert(instance.GetType());
-            var stronglyTypedHateoasResource = (_sut as HateoasContext)?.GetOrInsert<T>();
-            var actualGetType = _sut.HasResource(instance.GetType());
-            var actualTypeof = _sut.HasResource(typeof(T));
+		[Theory]
+		[ConfigureData]
+		[Trait(nameof(IHateoasContext), nameof(HateoasContext.GetOrInsert))]
+		[Trait(nameof(IHateoasContext), nameof(IHateoasContext.HasResource))]
+		public void GetOrInsert_WithClassType_ReturnIHateoasResource<T>(T instance) where T : class
+		{
+			// act
+			var interfaceHateoasResource = (_sut as HateoasContext)?.GetOrInsert(instance.GetType());
+			var stronglyTypedHateoasResource = (_sut as HateoasContext)?.GetOrInsert<T>();
+			var actualGetType = _sut.HasResource(instance.GetType());
+			var actualTypeof = _sut.HasResource(typeof(T));
 
-            // assert
-            Assert.NotNull(stronglyTypedHateoasResource);
-            Assert.NotNull(interfaceHateoasResource);
-            Assert.Same(stronglyTypedHateoasResource, interfaceHateoasResource);
-            Assert.True(actualGetType);
-            Assert.True(actualTypeof);
-        }
+			// assert
+			Assert.NotNull(stronglyTypedHateoasResource);
+			Assert.NotNull(interfaceHateoasResource);
+			Assert.Same(stronglyTypedHateoasResource, interfaceHateoasResource);
+			Assert.True(actualGetType);
+			Assert.True(actualTypeof);
+		}
 
-        [Theory]
-        [ConfigureData]
-        [Trait(nameof(IHateoasContext), nameof(IHateoasContext.GetApplicableLinks))]
-        public void GetApplicableLinks_WithNotConfiguredType_ReturnEmptyList(Testee instance)
-        {
-            // arrange
-            var notConfiguredType = instance.GetType();
+		[Theory]
+		[ConfigureData]
+		[Trait(nameof(IHateoasContext), nameof(IHateoasContext.GetApplicableLinks))]
+		public void GetApplicableLinks_WithNotConfiguredType_ReturnEmptyList(Testee instance)
+		{
+			// arrange
+			var notConfiguredType = instance.GetType();
 
-            // act
-            var hateoasLinks = _sut.GetApplicableLinks(notConfiguredType, instance);
+			// act
+			var hateoasLinks = _sut.GetApplicableLinks(notConfiguredType, instance);
 
-            // assert
-            Assert.IsType<List<IHateoasLink>>(hateoasLinks);
-            Assert.Empty(hateoasLinks);
-        }
+			// assert
+			Assert.IsType<List<IHateoasLink>>(hateoasLinks);
+			Assert.Empty(hateoasLinks);
+		}
 
-        [Theory]
-        [ConfigureData]
-        [Trait(nameof(IHateoasContext), nameof(IHateoasContext.Configure))]
-        [Trait(nameof(IHateoasContext), nameof(IHateoasContext.GetApplicableLinks))]
-        public void GetApplicableLinks_WithConfiguredType_ReturnNotEmptyList<T>(T valid) where T : Testee
-        {
-            // arrange
-            var hateoasContext = _sut.Configure<T>(resource =>
-            {
-                resource.HasLink(valid.StringValue)
-                        .HasConditional(x => x.BoolValue)
-                        .HasRouteData(x => new { id = x.LongIntegerValue });
-            });
+		[Theory]
+		[ConfigureData]
+		[Trait(nameof(IHateoasContext), nameof(IHateoasContext.Configure))]
+		[Trait(nameof(IHateoasContext), nameof(IHateoasContext.GetApplicableLinks))]
+		public void GetApplicableLinks_WithConfiguredType_ReturnNotEmptyList<T>(T valid) where T : Testee
+		{
+			// arrange
+			var hateoasContext = _sut.Configure<T>(resource =>
+			{
+				resource.HasLink(valid.StringValue)
+				        .HasConditional(x => x.BoolValue)
+				        .HasRouteData(x => new {id = x.LongIntegerValue});
+			});
 
-            // assert
-            Assert.Same(_sut, hateoasContext);
-            ActNotEmptyHateoasLinks(valid);
-        }
+			// assert
+			Assert.Same(_sut, hateoasContext);
+			ActNotEmptyHateoasLinks(valid);
+		}
 
-        [Theory]
-        [ConfigurationData]
-        [Trait(nameof(IHateoasContext), nameof(IHateoasContext.ApplyConfiguration))]
-        [Trait(nameof(IHateoasContext), nameof(IHateoasContext.GetApplicableLinks))]
-        public void GetApplicableLinks_WithApplyConfigurationForType_ReturnNotEmptyList<T>(
-            IHateoasResourceConfiguration<T> config, T testee)
-            where T : Testee
-        {
-            // act
-            var hateoasContext = _sut.ApplyConfiguration(config);
-            ActNotEmptyHateoasLinks(testee);
+		[Theory]
+		[ConfigurationData]
+		[Trait(nameof(IHateoasContext), nameof(IHateoasContext.ApplyConfiguration))]
+		[Trait(nameof(IHateoasContext), nameof(IHateoasContext.GetApplicableLinks))]
+		public void GetApplicableLinks_WithApplyConfigurationForType_ReturnNotEmptyList<T>(
+			IHateoasResourceConfiguration<T> config, T testee)
+			where T : Testee
+		{
+			// act
+			var hateoasContext = _sut.ApplyConfiguration(config);
+			ActNotEmptyHateoasLinks(testee);
 
-            // assert
-            Assert.Same(_sut, hateoasContext);
-        }
+			// assert
+			Assert.Same(_sut, hateoasContext);
+		}
 
-        [Theory]
-        [ConfigurationData]
-        [Trait(nameof(IHateoasContext), nameof(IHateoasContext.ConfigureFromAssembly))]
-        [Trait(nameof(IHateoasContext), nameof(IHateoasContext.GetApplicableLinks))]
-        public void GetApplicableLinks_WithTypeConfiguredFromAssembly_ReturnNotEmptyList<T>(
-            IHateoasResourceConfiguration<T> testeeConfiguration, T testee)
-            where T : Testee
-        {
-            // act
-            var hateoasContext = _sut.ConfigureFromAssembly(testeeConfiguration.GetType().Assembly);
+		[Theory]
+		[ConfigurationData]
+		[Trait(nameof(IHateoasContext), nameof(IHateoasContext.ConfigureFromAssembly))]
+		[Trait(nameof(IHateoasContext), nameof(IHateoasContext.GetApplicableLinks))]
+		public void GetApplicableLinks_WithTypeConfiguredFromAssembly_ReturnNotEmptyList<T>(
+			IHateoasResourceConfiguration<T> testeeConfiguration, T testee)
+			where T : Testee
+		{
+			// act
+			var hateoasContext = _sut.ConfigureFromAssembly(testeeConfiguration.GetType().Assembly);
 
-            // assert
-            Assert.Same(_sut, hateoasContext);
-            ActNotEmptyHateoasLinks(testee);
-        }
+			// assert
+			Assert.Same(_sut, hateoasContext);
+			ActNotEmptyHateoasLinks(testee);
+		}
 
-        private void ActNotEmptyHateoasLinks<T>(T data) where T : Testee
-        {
-            // act
-            var hateoasLinks = _sut.GetApplicableLinks(typeof(T), data);
+		private void ActNotEmptyHateoasLinks<T>(T data) where T : Testee
+		{
+			// act
+			var hateoasLinks = _sut.GetApplicableLinks(typeof(T), data);
 
-            // assert
-            Assert.IsType<List<IHateoasLink>>(hateoasLinks);
-            Assert.NotEmpty(hateoasLinks);
-        }
+			// assert
+			Assert.IsType<List<IHateoasLink>>(hateoasLinks);
+			Assert.NotEmpty(hateoasLinks);
+		}
 
-        [Fact]
-        [Trait(nameof(IHateoasContext), nameof(IHateoasContext.Configure))]
-        [Trait(nameof(IHateoasContext), "Exceptions")]
-        public void Configure_WithResourceNull_ThrowsArgumentNullException()
-        {
-            // arrange
-            const string parameterName = "resource";
+		[Fact]
+		[Trait(nameof(IHateoasContext), nameof(IHateoasContext.ApplyConfiguration))]
+		[Trait(nameof(IHateoasContext), "Exceptions")]
+		public void ApplyConfiguration_WithResourceNull_ThrowsArgumentNullException()
+		{
+			// arrange
+			const string parameterName = "configuration";
 
-            // act
-            Action actual = () => _sut.Configure<Testee>(null);
+			// act
+			Action actual = () => _sut.ApplyConfiguration<Testee>(null);
 
-            // assert
-            Assert.Throws<ArgumentNullException>(parameterName, actual);
-        }
+			Assert.Throws<ArgumentNullException>(parameterName, actual);
+		}
 
-        [Fact]
-        [Trait(nameof(IHateoasContext), nameof(IHateoasContext.ApplyConfiguration))]
-        [Trait(nameof(IHateoasContext), "Exceptions")]
-        public void ApplyConfiguration_WithResourceNull_ThrowsArgumentNullException()
-        {
-            // arrange
-            const string parameterName = "configuration";
+		[Fact]
+		[Trait(nameof(IHateoasContext), nameof(IHateoasContext.Configure))]
+		[Trait(nameof(IHateoasContext), "Exceptions")]
+		public void Configure_WithResourceNull_ThrowsArgumentNullException()
+		{
+			// arrange
+			const string parameterName = "resource";
 
-            // act
-            Action actual = () => _sut.ApplyConfiguration<Testee>(null);
+			// act
+			Action actual = () => _sut.Configure<Testee>(null);
 
-            Assert.Throws<ArgumentNullException>(parameterName, actual);
-        }
+			// assert
+			Assert.Throws<ArgumentNullException>(parameterName, actual);
+		}
 
-        [Fact]
-        [Trait(nameof(IHateoasContext), nameof(IHateoasContext.ConfigureFromAssembly))]
-        [Trait(nameof(IHateoasContext), "Exceptions")]
-        public void ConfigureFromAssembly_WithResourceNull_ThrowsArgumentNullException()
-        {
-            // arrange
-            const string parameterName = "assembly";
+		[Fact]
+		[Trait(nameof(IHateoasContext), nameof(IHateoasContext.ConfigureFromAssembly))]
+		[Trait(nameof(IHateoasContext), "Exceptions")]
+		public void ConfigureFromAssembly_WhenHasNo_IHateoasResourceConfiguration_ThrowsTargetException()
+		{
+			// act
+			Action actual = () => _sut.ConfigureFromAssembly(typeof(string).Assembly);
 
-            // act
-            Action actual = () => _sut.ConfigureFromAssembly(null);
+			// assert
+			Assert.Throws<TargetException>(actual);
+		}
 
-            // assert
-            Assert.Throws<ArgumentNullException>(parameterName, actual);
-        }
+		[Fact]
+		[Trait(nameof(IHateoasContext), nameof(IHateoasContext.ConfigureFromAssembly))]
+		[Trait(nameof(IHateoasContext), "Exceptions")]
+		public void ConfigureFromAssembly_WithResourceNull_ThrowsArgumentNullException()
+		{
+			// arrange
+			const string parameterName = "assembly";
 
-        [Fact]
-        [Trait(nameof(IHateoasContext), nameof(IHateoasContext.ConfigureFromAssembly))]
-        [Trait(nameof(IHateoasContext), "Exceptions")]
-        public void ConfigureFromAssembly_WhenHasNo_IHateoasResourceConfiguration_ThrowsTargetException()
-        {
-            // act
-            Action actual = () => _sut.ConfigureFromAssembly(typeof(string).Assembly);
+			// act
+			Action actual = () => _sut.ConfigureFromAssembly(null);
 
-            // assert
-            Assert.Throws<TargetException>(actual);
-        }
+			// assert
+			Assert.Throws<ArgumentNullException>(parameterName, actual);
+		}
 
-        /// <inheritdoc />
-        public void Dispose()
-        {
-            GC.SuppressFinalize(this);
-        }
-    }
+		[Fact]
+		[Trait(nameof(IHateoasContext), "New")]
+		public void New_WithOutParameters_HateoasContext()
+		{
+			Assert.IsAssignableFrom<IHateoasContext>(_sut);
+			Assert.IsType<HateoasContext>(_sut);
+		}
+	}
 }

--- a/HateoasNet.Tests/Configurations/HateoasLinkTests/HasConditionalDataAttribute.cs
+++ b/HateoasNet.Tests/Configurations/HateoasLinkTests/HasConditionalDataAttribute.cs
@@ -1,56 +1,56 @@
-﻿using HateoasNet.TestingObjects;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using HateoasNet.TestingObjects;
 using Xunit.Sdk;
 
 namespace HateoasNet.Tests.Configurations.HateoasLinkTests
 {
-    public class HasConditionalDataAttribute : DataAttribute
-    {
-        /// <inheritdoc />
-        public override IEnumerable<object[]> GetData(MethodInfo testMethod)
-        {
-            var testee = new Testee();
-            var nestedTestee = new NestedTestee();
-            var genericTestee = new GenericTestee<Testee> { Nested = testee, Collection = new List<Testee> { testee } };
+	public class HasConditionalDataAttribute : DataAttribute
+	{
+		/// <inheritdoc />
+		public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+		{
+			var testee = new Testee();
+			var nestedTestee = new NestedTestee();
+			var genericTestee = new GenericTestee<Testee> {Nested = testee, Collection = new List<Testee> {testee}};
 
-            yield return new object[] { testee, new Func<Testee, bool>(x => x.BoolValue) };
-            yield return new object[] { testee, new Func<Testee, bool>(x => x.DecimalValue > 2000m) };
-            yield return new object[] { testee, new Func<Testee, bool>(x => !string.IsNullOrWhiteSpace(x.StringValue)) };
-            yield return new object[] { testee, new Func<Testee, bool>(x => x.DecimalValue == new decimal(x.FloatValue)) };
+			yield return new object[] {testee, new Func<Testee, bool>(x => x.BoolValue)};
+			yield return new object[] {testee, new Func<Testee, bool>(x => x.DecimalValue > 2000m)};
+			yield return new object[] {testee, new Func<Testee, bool>(x => !string.IsNullOrWhiteSpace(x.StringValue))};
+			yield return new object[] {testee, new Func<Testee, bool>(x => x.DecimalValue == new decimal(x.FloatValue))};
 
-            yield return new object[] { nestedTestee, new Func<NestedTestee, bool>(x => x.Nested.BoolValue) };
-            yield return new object[] { nestedTestee, new Func<NestedTestee, bool>(x => x.Nested.DecimalValue > 2000m) };
-            yield return new object[]
-            {
-                nestedTestee, new Func<NestedTestee, bool>(x => !string.IsNullOrWhiteSpace(x.Nested.StringValue))
-            };
-            yield return new object[]
-            {
-                nestedTestee, new Func<NestedTestee, bool>(x => x.DecimalValue == new decimal(x.Nested.FloatValue))
-            };
+			yield return new object[] {nestedTestee, new Func<NestedTestee, bool>(x => x.Nested.BoolValue)};
+			yield return new object[] {nestedTestee, new Func<NestedTestee, bool>(x => x.Nested.DecimalValue > 2000m)};
+			yield return new object[]
+			{
+				nestedTestee, new Func<NestedTestee, bool>(x => !string.IsNullOrWhiteSpace(x.Nested.StringValue))
+			};
+			yield return new object[]
+			{
+				nestedTestee, new Func<NestedTestee, bool>(x => x.DecimalValue == new decimal(x.Nested.FloatValue))
+			};
 
-            yield return new object[]
-            {
-                genericTestee,
-                new Func<GenericTestee<Testee>, bool>(x => x.Collection.First().BoolValue)
-            };
-            yield return new object[]
-            {
-                genericTestee, new Func<GenericTestee<Testee>, bool>(x => x.Collection.First().DecimalValue > 2000m)
-            };
-            yield return new object[]
-            {
-                genericTestee,
-                new Func<GenericTestee<Testee>, bool>(x => !string.IsNullOrWhiteSpace(x.Collection.First().StringValue))
-            };
-            yield return new object[]
-            {
-                genericTestee,
-                new Func<GenericTestee<Testee>, bool>(x => x.Collection.First().DecimalValue == new decimal(x.FloatValue))
-            };
-        }
-    }
+			yield return new object[]
+			{
+				genericTestee,
+				new Func<GenericTestee<Testee>, bool>(x => x.Collection.First().BoolValue)
+			};
+			yield return new object[]
+			{
+				genericTestee, new Func<GenericTestee<Testee>, bool>(x => x.Collection.First().DecimalValue > 2000m)
+			};
+			yield return new object[]
+			{
+				genericTestee,
+				new Func<GenericTestee<Testee>, bool>(x => !string.IsNullOrWhiteSpace(x.Collection.First().StringValue))
+			};
+			yield return new object[]
+			{
+				genericTestee,
+				new Func<GenericTestee<Testee>, bool>(x => x.Collection.First().DecimalValue == new decimal(x.FloatValue))
+			};
+		}
+	}
 }

--- a/HateoasNet.Tests/Configurations/HateoasLinkTests/HateoasLinkCollectionFixture.cs
+++ b/HateoasNet.Tests/Configurations/HateoasLinkTests/HateoasLinkCollectionFixture.cs
@@ -3,8 +3,8 @@ using Xunit;
 
 namespace HateoasNet.Tests.Configurations.HateoasLinkTests
 {
-    [CollectionDefinition(nameof(IHateoasLink))]
-    public class HateoasLinkCollectionFixture : ICollectionFixture<HateoasLinkFixture>
-    {
-    }
+	[CollectionDefinition(nameof(IHateoasLink))]
+	public class HateoasLinkCollectionFixture : ICollectionFixture<HateoasLinkFixture>
+	{
+	}
 }

--- a/HateoasNet.Tests/Configurations/HateoasLinkTests/HateoasLinkFixture.cs
+++ b/HateoasNet.Tests/Configurations/HateoasLinkTests/HateoasLinkFixture.cs
@@ -1,23 +1,23 @@
-﻿using HateoasNet.Abstractions;
+﻿using System;
+using HateoasNet.Abstractions;
 using HateoasNet.Configurations;
 using HateoasNet.TestingObjects;
-using System;
 
 namespace HateoasNet.Tests.Configurations.HateoasLinkTests
 {
-    public class HateoasLinkFixture : IDisposable
-    {
-        public HateoasLinkFixture()
-        {
-            Sut = new HateoasLink<Testee>("test");
-        }
+	public class HateoasLinkFixture : IDisposable
+	{
+		public HateoasLinkFixture()
+		{
+			Sut = new HateoasLink<Testee>("test");
+		}
 
-        public IHateoasLink<Testee> Sut { get; private set; }
+		public IHateoasLink<Testee> Sut { get; private set; }
 
-        public void Dispose()
-        {
-            Sut = null;
-            GC.SuppressFinalize(this);
-        }
-    }
+		public void Dispose()
+		{
+			Sut = null;
+			GC.SuppressFinalize(this);
+		}
+	}
 }

--- a/HateoasNet.Tests/Configurations/HateoasLinkTests/HateoasLinkShould.cs
+++ b/HateoasNet.Tests/Configurations/HateoasLinkTests/HateoasLinkShould.cs
@@ -33,7 +33,7 @@ namespace HateoasNet.Tests.Configurations.HateoasLinkTests
             // assert
             Assert.NotNull(_fixture.Sut.RouteName);
             Assert.NotNull(_fixture.Sut.RouteDictionaryFunction);
-            Assert.NotNull(_fixture.Sut.PredicateFunction);
+            Assert.NotNull(_fixture.Sut.Predicate);
         }
 
         [Fact]

--- a/HateoasNet.Tests/Configurations/HateoasLinkTests/HateoasLinkShould.cs
+++ b/HateoasNet.Tests/Configurations/HateoasLinkTests/HateoasLinkShould.cs
@@ -1,149 +1,149 @@
-﻿using HateoasNet.Abstractions;
+﻿using System;
+using HateoasNet.Abstractions;
 using HateoasNet.Configurations;
 using HateoasNet.TestingObjects;
 using HateoasNet.Tests.TestHelpers;
-using System;
 using Xunit;
 
 namespace HateoasNet.Tests.Configurations.HateoasLinkTests
 {
-    [Collection(nameof(IHateoasLink))]
-    public class HateoasLinkShould
-    {
-        public HateoasLinkShould(HateoasLinkFixture fixture)
-        {
-            _fixture = fixture;
-        }
+	[Collection(nameof(IHateoasLink))]
+	public class HateoasLinkShould
+	{
+		public HateoasLinkShould(HateoasLinkFixture fixture)
+		{
+			_fixture = fixture;
+		}
 
-        private readonly HateoasLinkFixture _fixture;
+		private readonly HateoasLinkFixture _fixture;
 
-        [Fact]
-        [Trait(nameof(IHateoasLink), "New")]
-        public void New_WithValidParameters_ReturnsHateoasLink()
-        {
-            Assert.IsAssignableFrom<IHateoasLink>(_fixture.Sut);
-            Assert.IsAssignableFrom<IHateoasLink<Testee>>(_fixture.Sut);
-            Assert.IsType<HateoasLink<Testee>>(_fixture.Sut);
-        }
+		[Theory]
+		[HasConditionalData]
+		[Trait(nameof(IHateoasLink), nameof(IHateoasLink.IsApplicable))]
+		[Trait(nameof(IHateoasLink), nameof(IHateoasLink<Testee>.HasConditional))]
+		public void IsApplicable_And_HasConditionalParameterFunction_ReturnsSameValue<T>(T testee, Func<T, bool> function)
+			where T : Testee
+		{
+			// arrange
+			var newSut = new HateoasLink<T>(typeof(T).Name);
+			var expected = function(testee);
+			var hateoasLink = newSut.HasConditional(function);
 
-        [Fact]
-        [Trait(nameof(IHateoasLink), "New")]
-        public void HaveNotNullValues_For_RouteName_And_RouteDictionaryFunction_And_PredicateFunction()
-        {
-            // assert
-            Assert.NotNull(_fixture.Sut.RouteName);
-            Assert.NotNull(_fixture.Sut.RouteDictionaryFunction);
-            Assert.NotNull(_fixture.Sut.Predicate);
-        }
+			// act
+			var actual = newSut.IsApplicable(testee);
 
-        [Fact]
-        [Trait(nameof(IHateoasLink), nameof(IHateoasLink<Testee>.HasRouteData))]
-        [Trait(nameof(IHateoasLink), nameof(IHateoasLink<Testee>.RouteDictionaryFunction))]
-        public void HasRouteData_WithValidRouteDataFunction_ReturnIHateoasLink()
-        {
-            // act
-            var hateoasLink = _fixture.Sut.HasRouteData(x => new { id = x.LongIntegerValue, label = x.StringValue });
+			// assert
+			Assert.Same(newSut, hateoasLink);
+			Assert.Equal(expected, actual);
+		}
 
-            // assert
-            Assert.Same(_fixture.Sut, hateoasLink);
-            Assert.NotNull(_fixture.Sut.RouteDictionaryFunction);
-        }
+		[Theory]
+		[ConfigureData]
+		[Trait(nameof(IHateoasLink), nameof(IHateoasLink<Testee>.GetRouteDictionary))]
+		[Trait(nameof(IHateoasLink), nameof(IHateoasLink<Testee>.HasRouteData))]
+		public void GetRouteDictionary_And_HasRouteDataParameterFunction_ReturnsSameValue(Testee testee)
+		{
+			// act
+			var hateoasLink = _fixture.Sut.HasRouteData(x => new {id = x.LongIntegerValue, label = x.StringValue});
+			var expected = new {id = testee.LongIntegerValue, label = testee.StringValue}.ToRouteDictionary();
+			var actual = _fixture.Sut.GetRouteDictionary(testee);
 
-        [Theory]
-        [HasConditionalData]
-        [Trait(nameof(IHateoasLink), nameof(IHateoasLink.IsApplicable))]
-        [Trait(nameof(IHateoasLink), nameof(IHateoasLink<Testee>.HasConditional))]
-        public void IsApplicable_And_HasConditionalParameterFunction_ReturnsSameValue<T>(T testee, Func<T, bool> function)
-            where T : Testee
-        {
-            // arrange
-            var newSut = new HateoasLink<T>(typeof(T).Name);
-            var expected = function(testee);
-            var hateoasLink = newSut.HasConditional(function);
-
-            // act
-            var actual = newSut.IsApplicable(testee);
-
-            // assert
-            Assert.Same(newSut, hateoasLink);
-            Assert.Equal(expected, actual);
-        }
-
-        [Theory]
-        [ConfigureData]
-        [Trait(nameof(IHateoasLink), nameof(IHateoasLink<Testee>.GetRouteDictionary))]
-        [Trait(nameof(IHateoasLink), nameof(IHateoasLink<Testee>.HasRouteData))]
-        public void GetRouteDictionary_And_HasRouteDataParameterFunction_ReturnsSameValue(Testee testee)
-        {
-            // act
-            var hateoasLink = _fixture.Sut.HasRouteData(x => new { id = x.LongIntegerValue, label = x.StringValue });
-            var expected = new { id = testee.LongIntegerValue, label = testee.StringValue }.ToRouteDictionary();
-            var actual = _fixture.Sut.GetRouteDictionary(testee);
-
-            // assert
-            Assert.Same(_fixture.Sut, hateoasLink);
-            Assert.Equal(expected, actual);
-        }
+			// assert
+			Assert.Same(_fixture.Sut, hateoasLink);
+			Assert.Equal(expected, actual);
+		}
 
 
-        [Fact]
-        [Trait(nameof(IHateoasLink), nameof(IHateoasLink<Testee>.GetRouteDictionary))]
-        [Trait(nameof(IHateoasLink), "Exceptions")]
-        public void GetRouteDictionary_WithResourceDataNull_ThrowsArgumentNullException()
-        {
-            // arrange
-            const string parameterName = "resourceData";
+		[Fact]
+		[Trait(nameof(IHateoasLink), nameof(IHateoasLink<Testee>.GetRouteDictionary))]
+		[Trait(nameof(IHateoasLink), "Exceptions")]
+		public void GetRouteDictionary_WithResourceDataNull_ThrowsArgumentNullException()
+		{
+			// arrange
+			const string parameterName = "resourceData";
 
-            // act
-            Action actual = () => _fixture.Sut.GetRouteDictionary(null);
+			// act
+			Action actual = () => _fixture.Sut.GetRouteDictionary(null);
 
-            // assert
-            Assert.Throws<ArgumentNullException>(parameterName, actual);
-        }
+			// assert
+			Assert.Throws<ArgumentNullException>(parameterName, actual);
+		}
 
-        [Fact]
-        [Trait(nameof(IHateoasLink), nameof(IHateoasLink<Testee>.HasConditional))]
-        [Trait(nameof(IHateoasLink), "Exceptions")]
-        public void HasConditional_WithPredicateNull_ThrowsArgumentNullException()
-        {
-            // arrange
-            const string parameterName = "predicate";
+		[Fact]
+		[Trait(nameof(IHateoasLink), nameof(IHateoasLink<Testee>.HasConditional))]
+		[Trait(nameof(IHateoasLink), "Exceptions")]
+		public void HasConditional_WithPredicateNull_ThrowsArgumentNullException()
+		{
+			// arrange
+			const string parameterName = "predicate";
 
-            // act
-            Action actual = () => _fixture.Sut.HasConditional(null);
+			// act
+			Action actual = () => _fixture.Sut.HasConditional(null);
 
-            // assert
-            Assert.Throws<ArgumentNullException>(parameterName, actual);
-        }
+			// assert
+			Assert.Throws<ArgumentNullException>(parameterName, actual);
+		}
 
-        [Fact]
-        [Trait(nameof(IHateoasLink), nameof(IHateoasLink<Testee>.HasRouteData))]
-        [Trait(nameof(IHateoasLink), "Exceptions")]
-        public void HasRouteData_WithRouteDataFunctionNull_ThrowsArgumentNullException()
-        {
-            // arrange
-            const string parameterName = "routeDataFunction";
+		[Fact]
+		[Trait(nameof(IHateoasLink), nameof(IHateoasLink<Testee>.HasRouteData))]
+		[Trait(nameof(IHateoasLink), "Exceptions")]
+		public void HasRouteData_WithRouteDataFunctionNull_ThrowsArgumentNullException()
+		{
+			// arrange
+			const string parameterName = "routeDataFunction";
 
-            // act
-            Action actual = () => _fixture.Sut.HasRouteData(null);
+			// act
+			Action actual = () => _fixture.Sut.HasRouteData(null);
 
-            // assert
-            Assert.Throws<ArgumentNullException>(parameterName, actual);
-        }
+			// assert
+			Assert.Throws<ArgumentNullException>(parameterName, actual);
+		}
 
-        [Fact]
-        [Trait(nameof(IHateoasLink), nameof(IHateoasLink.IsApplicable))]
-        [Trait(nameof(IHateoasLink), "Exceptions")]
-        public void IsApplicable_WithResourceDataNull_ThrowsArgumentNullException()
-        {
-            // arrange
-            const string parameterName = "resourceData";
+		[Fact]
+		[Trait(nameof(IHateoasLink), nameof(IHateoasLink<Testee>.HasRouteData))]
+		[Trait(nameof(IHateoasLink), nameof(IHateoasLink<Testee>.RouteDictionaryFunction))]
+		public void HasRouteData_WithValidRouteDataFunction_ReturnIHateoasLink()
+		{
+			// act
+			var hateoasLink = _fixture.Sut.HasRouteData(x => new {id = x.LongIntegerValue, label = x.StringValue});
 
-            // act
-            Action actual = () => _fixture.Sut.IsApplicable(null);
+			// assert
+			Assert.Same(_fixture.Sut, hateoasLink);
+			Assert.NotNull(_fixture.Sut.RouteDictionaryFunction);
+		}
 
-            // assert
-            Assert.Throws<ArgumentNullException>(parameterName, actual);
-        }
-    }
+		[Fact]
+		[Trait(nameof(IHateoasLink), "New")]
+		public void HaveNotNullValues_For_RouteName_And_RouteDictionaryFunction_And_PredicateFunction()
+		{
+			// assert
+			Assert.NotNull(_fixture.Sut.RouteName);
+			Assert.NotNull(_fixture.Sut.RouteDictionaryFunction);
+			Assert.NotNull(_fixture.Sut.Predicate);
+		}
+
+		[Fact]
+		[Trait(nameof(IHateoasLink), nameof(IHateoasLink.IsApplicable))]
+		[Trait(nameof(IHateoasLink), "Exceptions")]
+		public void IsApplicable_WithResourceDataNull_ThrowsArgumentNullException()
+		{
+			// arrange
+			const string parameterName = "resourceData";
+
+			// act
+			Action actual = () => _fixture.Sut.IsApplicable(null);
+
+			// assert
+			Assert.Throws<ArgumentNullException>(parameterName, actual);
+		}
+
+		[Fact]
+		[Trait(nameof(IHateoasLink), "New")]
+		public void New_WithValidParameters_ReturnsHateoasLink()
+		{
+			Assert.IsAssignableFrom<IHateoasLink>(_fixture.Sut);
+			Assert.IsAssignableFrom<IHateoasLink<Testee>>(_fixture.Sut);
+			Assert.IsType<HateoasLink<Testee>>(_fixture.Sut);
+		}
+	}
 }

--- a/HateoasNet.Tests/Configurations/HateoasResourceTests.cs
+++ b/HateoasNet.Tests/Configurations/HateoasResourceTests.cs
@@ -5,6 +5,7 @@ using HateoasNet.Tests.TestHelpers;
 using System;
 using System.Collections.Generic;
 using Xunit;
+// ReSharper disable xUnit1026
 
 namespace HateoasNet.Tests.Configurations
 {
@@ -19,6 +20,7 @@ namespace HateoasNet.Tests.Configurations
             var sut = new HateoasResource<T>();
 
             // assert
+            Assert.NotNull(testee);
             Assert.IsAssignableFrom<IHateoasResource>(sut);
             Assert.IsAssignableFrom<IHateoasResource<T>>(sut);
             Assert.IsType<HateoasResource<T>>(sut);
@@ -34,6 +36,7 @@ namespace HateoasNet.Tests.Configurations
             var hateoasLink = sut.HasLink(testee.GetType().Name);
 
             // assert
+            Assert.NotNull(testee);
             Assert.NotNull(hateoasLink);
             Assert.IsAssignableFrom<IHateoasLink>(hateoasLink);
             Assert.IsAssignableFrom<IHateoasLink<T>>(hateoasLink);
@@ -42,8 +45,8 @@ namespace HateoasNet.Tests.Configurations
 
         [Theory]
         [ConfigureData]
-        [Trait(nameof(IHateoasResource), "GetLinks")]
-        public void GetLinks_FromHateoasResource_WithOutConfiguredLinks_ReturnsEmptyLinks<T>(T _) where T : Testee
+        [Trait(nameof(IHateoasResource), nameof(IHateoasResource.GetLinks))]
+        public void GetLinks_FromHateoasResource_WithOutConfiguredLinks_ReturnsEmptyLinks<T>(T testee) where T : Testee
         {
             // arrange
             var sut = new HateoasResource<T>();
@@ -52,6 +55,7 @@ namespace HateoasNet.Tests.Configurations
             var hateoasLinks = sut.GetLinks();
 
             // assert
+            Assert.NotNull(testee);
             Assert.IsAssignableFrom<IEnumerable<IHateoasLink>>(hateoasLinks);
             Assert.IsType<List<IHateoasLink>>(hateoasLinks);
             Assert.Empty(hateoasLinks);
@@ -59,11 +63,11 @@ namespace HateoasNet.Tests.Configurations
 
         [Theory]
         [ConfigureData]
-        [Trait(nameof(IHateoasResource), nameof(IHateoasResource<Testee>.GetLinks))]
-        public void GetLinks_FromHateoasResource_WithConfiguredLinks_ReturnsNotEmptyLinks<T>(T _) where T : Testee
+        [Trait(nameof(IHateoasResource), nameof(IHateoasResource.GetLinks))]
+        public void GetLinks_FromHateoasResource_WithConfiguredLinks_ReturnsNotEmptyLinks<T>(T testee) where T : Testee
         {
             // arrange
-            const string routeName = "test";
+            const string routeName = nameof(testee);
             var sut = new HateoasResource<T>();
 
             // act

--- a/HateoasNet.Tests/Configurations/HateoasResourceTests.cs
+++ b/HateoasNet.Tests/Configurations/HateoasResourceTests.cs
@@ -1,110 +1,111 @@
-﻿using HateoasNet.Abstractions;
+﻿using System;
+using System.Collections.Generic;
+using HateoasNet.Abstractions;
 using HateoasNet.Configurations;
 using HateoasNet.TestingObjects;
 using HateoasNet.Tests.TestHelpers;
-using System;
-using System.Collections.Generic;
 using Xunit;
+
 // ReSharper disable xUnit1026
 
 namespace HateoasNet.Tests.Configurations
 {
-    public class HateoasResourceTests : IDisposable
-    {
-        [Theory]
-        [ConfigureData]
-        [Trait(nameof(IHateoasResource), "New")]
-        public void New_WithTypeParameter_CreatesHateoasResource<T>(T testee) where T : Testee
-        {
-            // act
-            var sut = new HateoasResource<T>();
+	public class HateoasResourceTests : IDisposable
+	{
+		/// <inheritdoc />
+		public void Dispose()
+		{
+			GC.SuppressFinalize(this);
+		}
 
-            // assert
-            Assert.NotNull(testee);
-            Assert.IsAssignableFrom<IHateoasResource>(sut);
-            Assert.IsAssignableFrom<IHateoasResource<T>>(sut);
-            Assert.IsType<HateoasResource<T>>(sut);
-        }
+		[Theory]
+		[ConfigureData]
+		[Trait(nameof(IHateoasResource), "New")]
+		public void New_WithTypeParameter_CreatesHateoasResource<T>(T testee) where T : Testee
+		{
+			// act
+			var sut = new HateoasResource<T>();
 
-        [Theory]
-        [ConfigureData]
-        [Trait(nameof(IHateoasResource), nameof(IHateoasResource<Testee>.HasLink))]
-        public void HasLink_WithNotEmptyString_ReturnsHateoasLink<T>(T testee) where T : class
-        {
-            // act
-            var sut = new HateoasResource<T>();
-            var hateoasLink = sut.HasLink(testee.GetType().Name);
+			// assert
+			Assert.NotNull(testee);
+			Assert.IsAssignableFrom<IHateoasResource>(sut);
+			Assert.IsAssignableFrom<IHateoasResource<T>>(sut);
+			Assert.IsType<HateoasResource<T>>(sut);
+		}
 
-            // assert
-            Assert.NotNull(testee);
-            Assert.NotNull(hateoasLink);
-            Assert.IsAssignableFrom<IHateoasLink>(hateoasLink);
-            Assert.IsAssignableFrom<IHateoasLink<T>>(hateoasLink);
-            Assert.IsType<HateoasLink<T>>(hateoasLink);
-        }
+		[Theory]
+		[ConfigureData]
+		[Trait(nameof(IHateoasResource), nameof(IHateoasResource<Testee>.HasLink))]
+		public void HasLink_WithNotEmptyString_ReturnsHateoasLink<T>(T testee) where T : class
+		{
+			// act
+			var sut = new HateoasResource<T>();
+			var hateoasLink = sut.HasLink(testee.GetType().Name);
 
-        [Theory]
-        [ConfigureData]
-        [Trait(nameof(IHateoasResource), nameof(IHateoasResource.GetLinks))]
-        public void GetLinks_FromHateoasResource_WithOutConfiguredLinks_ReturnsEmptyLinks<T>(T testee) where T : Testee
-        {
-            // arrange
-            var sut = new HateoasResource<T>();
+			// assert
+			Assert.NotNull(testee);
+			Assert.NotNull(hateoasLink);
+			Assert.IsAssignableFrom<IHateoasLink>(hateoasLink);
+			Assert.IsAssignableFrom<IHateoasLink<T>>(hateoasLink);
+			Assert.IsType<HateoasLink<T>>(hateoasLink);
+		}
 
-            // act
-            var hateoasLinks = sut.GetLinks();
+		[Theory]
+		[ConfigureData]
+		[Trait(nameof(IHateoasResource), nameof(IHateoasResource.GetLinks))]
+		public void GetLinks_FromHateoasResource_WithOutConfiguredLinks_ReturnsEmptyLinks<T>(T testee) where T : Testee
+		{
+			// arrange
+			var sut = new HateoasResource<T>();
 
-            // assert
-            Assert.NotNull(testee);
-            Assert.IsAssignableFrom<IEnumerable<IHateoasLink>>(hateoasLinks);
-            Assert.IsType<List<IHateoasLink>>(hateoasLinks);
-            Assert.Empty(hateoasLinks);
-        }
+			// act
+			var hateoasLinks = sut.GetLinks();
 
-        [Theory]
-        [ConfigureData]
-        [Trait(nameof(IHateoasResource), nameof(IHateoasResource.GetLinks))]
-        public void GetLinks_FromHateoasResource_WithConfiguredLinks_ReturnsNotEmptyLinks<T>(T testee) where T : Testee
-        {
-            // arrange
-            const string routeName = nameof(testee);
-            var sut = new HateoasResource<T>();
+			// assert
+			Assert.NotNull(testee);
+			Assert.IsAssignableFrom<IEnumerable<IHateoasLink>>(hateoasLinks);
+			Assert.IsType<List<IHateoasLink>>(hateoasLinks);
+			Assert.Empty(hateoasLinks);
+		}
 
-            // act
-            var hateoasLink = sut.HasLink(routeName);
-            var hateoasLinks = sut.GetLinks();
+		[Theory]
+		[ConfigureData]
+		[Trait(nameof(IHateoasResource), nameof(IHateoasResource.GetLinks))]
+		public void GetLinks_FromHateoasResource_WithConfiguredLinks_ReturnsNotEmptyLinks<T>(T testee) where T : Testee
+		{
+			// arrange
+			const string routeName = nameof(testee);
+			var sut = new HateoasResource<T>();
 
-            // assert
-            Assert.IsAssignableFrom<IEnumerable<IHateoasLink>>(hateoasLinks);
-            Assert.IsType<List<IHateoasLink>>(hateoasLinks);
-            Assert.IsAssignableFrom<IHateoasLink>(hateoasLink);
-            Assert.IsAssignableFrom<IHateoasLink<T>>(hateoasLink);
-            Assert.IsType<HateoasLink<T>>(hateoasLink);
-            Assert.Contains(hateoasLinks, x => x.Equals(hateoasLink));
-        }
+			// act
+			var hateoasLink = sut.HasLink(routeName);
+			var hateoasLinks = sut.GetLinks();
+
+			// assert
+			Assert.IsAssignableFrom<IEnumerable<IHateoasLink>>(hateoasLinks);
+			Assert.IsType<List<IHateoasLink>>(hateoasLinks);
+			Assert.IsAssignableFrom<IHateoasLink>(hateoasLink);
+			Assert.IsAssignableFrom<IHateoasLink<T>>(hateoasLink);
+			Assert.IsType<HateoasLink<T>>(hateoasLink);
+			Assert.Contains(hateoasLinks, x => x.Equals(hateoasLink));
+		}
 
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        [Trait(nameof(IHateoasResource), nameof(IHateoasResource<Testee>.HasLink))]
-        [Trait(nameof(IHateoasResource), "Exceptions")]
-        public void HasLink_WithRouteNameNullOrEmpty_ThrowsArgumentNullException(string routeName)
-        {
-            // arrange
-            var sut = new HateoasResource<Testee>();
-            const string parameterName = "routeName";
+		[Theory]
+		[InlineData(null)]
+		[InlineData("")]
+		[Trait(nameof(IHateoasResource), nameof(IHateoasResource<Testee>.HasLink))]
+		[Trait(nameof(IHateoasResource), "Exceptions")]
+		public void HasLink_WithRouteNameNullOrEmpty_ThrowsArgumentNullException(string routeName)
+		{
+			// arrange
+			var sut = new HateoasResource<Testee>();
+			const string parameterName = "routeName";
 
-            // act
-            Action actual = () => sut.HasLink(routeName);
+			// act
+			Action actual = () => sut.HasLink(routeName);
 
-            Assert.Throws<ArgumentNullException>(parameterName, actual);
-        }
-
-        /// <inheritdoc />
-        public void Dispose()
-        {
-            GC.SuppressFinalize(this);
-        }
-    }
+			Assert.Throws<ArgumentNullException>(parameterName, actual);
+		}
+	}
 }

--- a/HateoasNet.Tests/Factories/ResourceFactoryTests.cs
+++ b/HateoasNet.Tests/Factories/ResourceFactoryTests.cs
@@ -40,13 +40,13 @@ namespace HateoasNet.Tests.Factories
             {
                 case IEnumerable enumerable:
                     var enumerableResource = _sut.Create(enumerable, typeof(T));
-                    innerLinks = enumerableResource.EnumerableData.SelectMany(x => x.Links).ToList();
+                    innerLinks = enumerableResource.GetItems().SelectMany(x => x.Links).ToList();
                     resource = enumerableResource;
                     break;
 
                 case IPagination pagination:
                     var paginationResource = _sut.Create(pagination, typeof(T));
-                    innerLinks = paginationResource.EnumerableData.SelectMany(x => x.Links).ToList();
+                    innerLinks = paginationResource.GetItems().SelectMany(x => x.Links).ToList();
                     resource = paginationResource;
                     break;
 

--- a/HateoasNet.Tests/Factories/ResourceFactoryTests.cs
+++ b/HateoasNet.Tests/Factories/ResourceFactoryTests.cs
@@ -1,139 +1,145 @@
-﻿using HateoasNet.Abstractions;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using HateoasNet.Abstractions;
 using HateoasNet.Factories;
 using HateoasNet.Resources;
 using HateoasNet.Tests.TestHelpers;
 using Moq;
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using Xunit;
 
 namespace HateoasNet.Tests.Factories
 {
-    public class ResourceFactoryTests : IDisposable
-    {
-        public ResourceFactoryTests()
-        {
-            _mockHateoasContext = new Mock<IHateoasContext>();
-            _mockResourceLinkFactory = new Mock<IResourceLinkFactory>();
-            _sut = new ResourceFactory(_mockHateoasContext.Object, _mockResourceLinkFactory.Object);
-        }
+	public class ResourceFactoryTests : IDisposable
+	{
+		private readonly Mock<IHateoasContext> _mockHateoasContext;
+		private readonly Mock<IResourceLinkFactory> _mockResourceLinkFactory;
+		private readonly IResourceFactory _sut;
 
-        private readonly Mock<IHateoasContext> _mockHateoasContext;
-        private readonly Mock<IResourceLinkFactory> _mockResourceLinkFactory;
-        private readonly IResourceFactory _sut;
+		public ResourceFactoryTests()
+		{
+			_mockHateoasContext = new Mock<IHateoasContext>();
+			_mockResourceLinkFactory = new Mock<IResourceLinkFactory>();
+			_sut = new ResourceFactory(_mockHateoasContext.Object, _mockResourceLinkFactory.Object);
+		}
 
-        [Theory]
-        [CreateResourceData]
-        [Trait(nameof(IResourceFactory), nameof(IResourceFactory.Create))]
-        public void Create_WithValidParameters_ReturnsValidFormattedResource<T>(T source) where T : class
-        {
-            // arrange
-            var resourceLink = GetResourceLinkFromMockArrangements<T>();
+		/// <inheritdoc />
+		public void Dispose()
+		{
+			GC.SuppressFinalize(this);
+		}
 
-            var innerLinks = new List<ResourceLink>();
+		[Theory]
+		[CreateResourceData]
+		[Trait(nameof(IResourceFactory), nameof(IResourceFactory.Create))]
+		public void Create_WithValidParameters_ReturnsValidFormattedResource<T>(T source) where T : class
+		{
+			// arrange
+			var resourceLink = GetResourceLinkFromMockArrangements<T>();
 
-            Resource resource;
-            // act
-            switch (source)
-            {
-                case IEnumerable enumerable:
-                    var enumerableResource = _sut.Create(enumerable, typeof(T));
-                    innerLinks = enumerableResource.GetItems().SelectMany(x => x.Links).ToList();
-                    resource = enumerableResource;
-                    break;
+			var innerLinks = new List<ResourceLink>();
 
-                case IPagination pagination:
-                    var paginationResource = _sut.Create(pagination, typeof(T));
-                    innerLinks = paginationResource.GetItems().SelectMany(x => x.Links).ToList();
-                    resource = paginationResource;
-                    break;
+			Resource resource;
+			// act
+			switch (source)
+			{
+				case IEnumerable enumerable:
+					var enumerableResource = _sut.Create(enumerable, typeof(T));
+					innerLinks = enumerableResource.GetItems().SelectMany(x => x.Links).ToList();
+					resource = enumerableResource;
+					break;
 
-                default:
-                    resource = _sut.Create(source, typeof(T));
-                    break;
-            }
+				case IPagination pagination:
+					var paginationResource = _sut.Create(pagination, typeof(T));
+					innerLinks = paginationResource.GetItems().SelectMany(x => x.Links).ToList();
+					resource = paginationResource;
+					break;
 
-            // assert
-            Assert.NotNull(resource);
-            Assert.IsAssignableFrom<Resource>(resource);
-            Assert.IsType<List<ResourceLink>>(resource.Links);
-            Assert.Contains(resourceLink, resource.Links);
-            Assert.True(innerLinks.All(l => l == resourceLink));
-        }
+				default:
+					resource = _sut.Create(source, typeof(T));
+					break;
+			}
 
-        [Theory]
-        [BuildResourceLinksData]
-        [Trait(nameof(IResourceFactory), nameof(ResourceFactory.BuildResourceLinks))]
-        public void BuildResourceLinks_WithValidParameters_AddsLinksToResource<T>(Resource resource, T source, Type type)
-            where T : class
+			// assert
+			Assert.NotNull(resource);
+			Assert.IsAssignableFrom<Resource>(resource);
+			Assert.IsType<List<ResourceLink>>(resource.Links);
+			Assert.Contains(resourceLink, resource.Links);
+			Assert.True(innerLinks.All(l => l == resourceLink));
+		}
 
-        {
-            // arrange
-            var wasEmptyBeforeAct = !resource.Links.Any();
-            var resourceLink = GetResourceLinkFromMockArrangements<T>();
+		[Theory]
+		[BuildResourceLinksData]
+		[Trait(nameof(IResourceFactory), nameof(ResourceFactory.BuildResourceLinks))]
+		public void BuildResourceLinks_WithValidParameters_AddsLinksToResource<T>(Resource resource, T source, Type type)
+			where T : class
 
-            // act
-            ((ResourceFactory)_sut).BuildResourceLinks(resource, source, type);
+		{
+			// arrange
+			var wasEmptyBeforeAct = !resource.Links.Any();
+			var resourceLink = GetResourceLinkFromMockArrangements<T>();
 
-            // assert
-            Assert.True(wasEmptyBeforeAct);
-            Assert.IsAssignableFrom<Resource>(resource);
-            Assert.IsType<List<ResourceLink>>(resource.Links);
-            Assert.Contains(resourceLink, resource.Links);
-        }
+			// act
+			((ResourceFactory) _sut).BuildResourceLinks(resource, source, type);
 
-        [Theory]
-        [EnumerateToResourceData]
-        [Trait(nameof(IResourceFactory), nameof(ResourceFactory.ToEnumerableOfResources))]
-        public void ToEnumerableOfResources_WithEnumerableOfTargetType_ReturnsIEnumerableOfSingleResource<T>(T source)
-            where T : class
-        {
-            // arrange
-            var resourceLink = GetResourceLinkFromMockArrangements<T>();
+			// assert
+			Assert.True(wasEmptyBeforeAct);
+			Assert.IsAssignableFrom<Resource>(resource);
+			Assert.IsType<List<ResourceLink>>(resource.Links);
+			Assert.Contains(resourceLink, resource.Links);
+		}
 
-            // act
-            var resources =
-                ((ResourceFactory)_sut).ToEnumerableOfResources(source as IEnumerable, typeof(T)).ToArray();
+		[Theory]
+		[EnumerateToResourceData]
+		[Trait(nameof(IResourceFactory), nameof(ResourceFactory.ToEnumerableOfResources))]
+		public void ToEnumerableOfResources_WithEnumerableOfTargetType_ReturnsIEnumerableOfSingleResource<T>(T source)
+			where T : class
+		{
+			// arrange
+			var resourceLink = GetResourceLinkFromMockArrangements<T>();
 
-            // assert
-            Assert.IsAssignableFrom<IEnumerable<Resource>>(resources);
-            Assert.NotEmpty(resources);
-            Assert.True(resources.All(x => x.Links.All(l => l == resourceLink)));
-        }
+			// act
+			var resources =
+				((ResourceFactory) _sut).ToEnumerableOfResources(source as IEnumerable, typeof(T)).ToArray();
 
-        private ResourceLink GetResourceLinkFromMockArrangements<T>() where T : class
-        {
-            // creating additional stubs
-            const string routeName = "test-route";
-            var resourceLink = new ResourceLink(routeName, GetDummyUrl(routeName), GetDummyMethod());
+			// assert
+			Assert.IsAssignableFrom<IEnumerable<Resource>>(resources);
+			Assert.NotEmpty(resources);
+			Assert.True(resources.All(x => x.Links.All(l => l == resourceLink)));
+		}
 
-            //mocking dependency methods
-            var mockHateoasLink = new Mock<IHateoasLink<T>>();
-            mockHateoasLink.Setup(x => x.RouteName).Returns(routeName);
-            mockHateoasLink.Setup(x => x.GetRouteDictionary(It.IsAny<object>()))
-                           .Returns(It.IsAny<IDictionary<string, object>>());
+		private ResourceLink GetResourceLinkFromMockArrangements<T>() where T : class
+		{
+			// creating additional stubs
+			const string routeName = "test-route";
+			var resourceLink = new ResourceLink(routeName, GetDummyUrl(routeName), GetDummyMethod());
 
-            _mockHateoasContext
-                .Setup(x => x.GetApplicableLinks(It.IsAny<Type>(), It.IsAny<object>()))
-                .Returns(new List<IHateoasLink> { mockHateoasLink.Object });
+			//mocking dependency methods
+			var mockHateoasLink = new Mock<IHateoasLink<T>>();
+			mockHateoasLink.Setup(x => x.RouteName).Returns(routeName);
+			mockHateoasLink.Setup(x => x.GetRouteDictionary(It.IsAny<object>()))
+			               .Returns(It.IsAny<IDictionary<string, object>>());
 
-            _mockResourceLinkFactory
-                .Setup(x => x.Create(It.IsAny<string>(), It.IsAny<IDictionary<string, object>>()))
-                .Returns(resourceLink);
+			_mockHateoasContext
+				.Setup(x => x.GetApplicableLinks(It.IsAny<Type>(), It.IsAny<object>()))
+				.Returns(new List<IHateoasLink> {mockHateoasLink.Object});
 
-            return resourceLink;
-        }
+			_mockResourceLinkFactory
+				.Setup(x => x.Create(It.IsAny<string>(), It.IsAny<IDictionary<string, object>>()))
+				.Returns(resourceLink);
 
-        private string GetDummyMethod() => new[] { "GET", "POST", "PUT", "PATCH", "DELETE" }[new Random().Next(0, 4)];
+			return resourceLink;
+		}
 
-        private string GetDummyUrl(string routeName) => $"http://hateoasnet.api/{routeName}";
+		private string GetDummyMethod()
+		{
+			return new[] {"GET", "POST", "PUT", "PATCH", "DELETE"}[new Random().Next(0, 4)];
+		}
 
-        /// <inheritdoc />
-        public void Dispose()
-        {
-            GC.SuppressFinalize(this);
-        }
-    }
+		private string GetDummyUrl(string routeName)
+		{
+			return $"http://hateoasnet.api/{routeName}";
+		}
+	}
 }

--- a/HateoasNet.Tests/HateoasNet.Tests.csproj
+++ b/HateoasNet.Tests/HateoasNet.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFrameworks>netcoreapp3.1;net472;</TargetFrameworks>
-
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/HateoasNet.Tests/TestHelpers/BuildResourceLinksDataAttribute.cs
+++ b/HateoasNet.Tests/TestHelpers/BuildResourceLinksDataAttribute.cs
@@ -1,27 +1,27 @@
-﻿using HateoasNet.Resources;
-using HateoasNet.TestingObjects;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using HateoasNet.Resources;
+using HateoasNet.TestingObjects;
 using Xunit.Sdk;
 
 namespace HateoasNet.Tests.TestHelpers
 {
-    public class BuildResourceLinksDataAttribute : DataAttribute
-    {
-        public override IEnumerable<object[]> GetData(MethodInfo testMethod)
-        {
-            var testee = new Testee();
-            var listTestee = new List<Testee> { testee };
-            var paginationTestee = new Pagination<Testee>(listTestee, 1, 10);
+	public class BuildResourceLinksDataAttribute : DataAttribute
+	{
+		public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+		{
+			var testee = new Testee();
+			var listTestee = new List<Testee> {testee};
+			var paginationTestee = new Pagination<Testee>(listTestee, 1, 10);
 
-            var singleResources = listTestee.Select(x => new SingleResource(x)).ToList();
-            var enumerableResource = new EnumerableResource(singleResources);
-            var paginationResources = new PaginationResource(singleResources, 1, 10, 1);
+			var singleResources = listTestee.Select(x => new SingleResource(x)).ToList();
+			var enumerableResource = new EnumerableResource(singleResources);
+			var paginationResources = new PaginationResource(singleResources, 1, 10, 1);
 
-            yield return new object[] { new SingleResource(testee), testee, typeof(Testee) };                //,(Testee) null};
-            yield return new object[] { enumerableResource, listTestee, typeof(List<Testee>) };              //, testee};
-            yield return new object[] { paginationResources, paginationTestee, typeof(Pagination<Testee>) }; //, testee};
-        }
-    }
+			yield return new object[] {new SingleResource(testee), testee, typeof(Testee)};                //,(Testee) null};
+			yield return new object[] {enumerableResource, listTestee, typeof(List<Testee>)};              //, testee};
+			yield return new object[] {paginationResources, paginationTestee, typeof(Pagination<Testee>)}; //, testee};
+		}
+	}
 }

--- a/HateoasNet.Tests/TestHelpers/ConfigurationDataAttribute.cs
+++ b/HateoasNet.Tests/TestHelpers/ConfigurationDataAttribute.cs
@@ -1,23 +1,23 @@
-﻿using HateoasNet.TestingObjects;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
+using HateoasNet.TestingObjects;
 using Xunit.Sdk;
 
 namespace HateoasNet.Tests.TestHelpers
 {
-    public class ConfigurationDataAttribute : DataAttribute
-    {
-        public override IEnumerable<object[]> GetData(MethodInfo testMethod)
-        {
-            yield return new object[] { new TesteeResourceConfiguration(), new Testee() };
-            yield return new object[] { new NestedTesteeResourceConfiguration(), new NestedTestee() };
-            yield return new object[]
-            {
-                new GenericTesteeResourceConfiguration(), new GenericTestee<object>
-                {
-                    Nested = new Testee(), Collection = new List<object> {new Testee()}
-                }
-            };
-        }
-    }
+	public class ConfigurationDataAttribute : DataAttribute
+	{
+		public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+		{
+			yield return new object[] {new TesteeResourceConfiguration(), new Testee()};
+			yield return new object[] {new NestedTesteeResourceConfiguration(), new NestedTestee()};
+			yield return new object[]
+			{
+				new GenericTesteeResourceConfiguration(), new GenericTestee<object>
+				{
+					Nested = new Testee(), Collection = new List<object> {new Testee()}
+				}
+			};
+		}
+	}
 }

--- a/HateoasNet.Tests/TestHelpers/ConfigureDataAttribute.cs
+++ b/HateoasNet.Tests/TestHelpers/ConfigureDataAttribute.cs
@@ -1,20 +1,20 @@
-﻿using HateoasNet.TestingObjects;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
+using HateoasNet.TestingObjects;
 using Xunit.Sdk;
 
 namespace HateoasNet.Tests.TestHelpers
 {
-    public class ConfigureDataAttribute : DataAttribute
-    {
-        public override IEnumerable<object[]> GetData(MethodInfo testMethod)
-        {
-            yield return new object[] { new Testee() };
-            yield return new object[] { new NestedTestee() };
-            yield return new object[]
-            {
-                new GenericTestee<object> {Nested = new Testee(), Collection = new List<object> {new Testee()}}
-            };
-        }
-    }
+	public class ConfigureDataAttribute : DataAttribute
+	{
+		public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+		{
+			yield return new object[] {new Testee()};
+			yield return new object[] {new NestedTestee()};
+			yield return new object[]
+			{
+				new GenericTestee<object> {Nested = new Testee(), Collection = new List<object> {new Testee()}}
+			};
+		}
+	}
 }

--- a/HateoasNet.Tests/TestHelpers/CreateResourceDataAttribute.cs
+++ b/HateoasNet.Tests/TestHelpers/CreateResourceDataAttribute.cs
@@ -1,35 +1,35 @@
-﻿using HateoasNet.Resources;
-using HateoasNet.TestingObjects;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
+using HateoasNet.Resources;
+using HateoasNet.TestingObjects;
 using Xunit.Sdk;
 
 namespace HateoasNet.Tests.TestHelpers
 {
-    public class CreateResourceDataAttribute : DataAttribute
-    {
-        /// <inheritdoc />
-        public override IEnumerable<object[]> GetData(MethodInfo testMethod)
-        {
-            // dummies
-            var testee = new Testee();
-            var nestedTestee = new NestedTestee();
-            var genericTesteeObject = new GenericTestee<object>();
-            var genericTesteeTestee = new GenericTestee<Testee>();
-            var genericTesteeNestedTestee = new GenericTestee<NestedTestee>();
-            var listTestee = new List<Testee>
-            {
-                testee, nestedTestee, genericTesteeObject, genericTesteeTestee, genericTesteeNestedTestee
-            };
-            var paginationTestee = new Pagination<Testee>(listTestee, 5, 2, 2);
+	public class CreateResourceDataAttribute : DataAttribute
+	{
+		/// <inheritdoc />
+		public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+		{
+			// dummies
+			var testee = new Testee();
+			var nestedTestee = new NestedTestee();
+			var genericTesteeObject = new GenericTestee<object>();
+			var genericTesteeTestee = new GenericTestee<Testee>();
+			var genericTesteeNestedTestee = new GenericTestee<NestedTestee>();
+			var listTestee = new List<Testee>
+			{
+				testee, nestedTestee, genericTesteeObject, genericTesteeTestee, genericTesteeNestedTestee
+			};
+			var paginationTestee = new Pagination<Testee>(listTestee, 5, 2, 2);
 
-            yield return new object[] { testee };
-            yield return new object[] { nestedTestee };
-            yield return new object[] { genericTesteeObject };
-            yield return new object[] { genericTesteeTestee };
-            yield return new object[] { genericTesteeNestedTestee };
-            yield return new object[] { listTestee };
-            yield return new object[] { paginationTestee };
-        }
-    }
+			yield return new object[] {testee};
+			yield return new object[] {nestedTestee};
+			yield return new object[] {genericTesteeObject};
+			yield return new object[] {genericTesteeTestee};
+			yield return new object[] {genericTesteeNestedTestee};
+			yield return new object[] {listTestee};
+			yield return new object[] {paginationTestee};
+		}
+	}
 }

--- a/HateoasNet.Tests/TestHelpers/EnumerateToResourceDataAttribute.cs
+++ b/HateoasNet.Tests/TestHelpers/EnumerateToResourceDataAttribute.cs
@@ -1,28 +1,28 @@
-﻿using HateoasNet.TestingObjects;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using HateoasNet.TestingObjects;
 using Xunit.Sdk;
 
 namespace HateoasNet.Tests.TestHelpers
 {
-    public class EnumerateToResourceDataAttribute : DataAttribute
-    {
-        /// <inheritdoc />
-        public override IEnumerable<object[]> GetData(MethodInfo testMethod)
-        {
-            yield return new object[]
-            {
-                new List<Testee>()
-                {
-                    new Testee(), new NestedTestee(), new GenericTestee<Testee>(),
-                    new GenericTestee<NestedTestee>(), new GenericTestee<object>()
-                }
-            };
-            yield return new object[] { Enumerable.Range(1, 5).Select(_ => new NestedTestee()).ToList() };
-            yield return new object[] { Enumerable.Range(1, 5).Select(_ => new GenericTestee<Testee>()).ToList() };
-            yield return new object[] { Enumerable.Range(1, 5).Select(_ => new GenericTestee<NestedTestee>()).ToList() };
-            yield return new object[] { Enumerable.Range(1, 5).Select(_ => new GenericTestee<object>()).ToList() };
-        }
-    }
+	public class EnumerateToResourceDataAttribute : DataAttribute
+	{
+		/// <inheritdoc />
+		public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+		{
+			yield return new object[]
+			{
+				new List<Testee>
+				{
+					new Testee(), new NestedTestee(), new GenericTestee<Testee>(),
+					new GenericTestee<NestedTestee>(), new GenericTestee<object>()
+				}
+			};
+			yield return new object[] {Enumerable.Range(1, 5).Select(_ => new NestedTestee()).ToList()};
+			yield return new object[] {Enumerable.Range(1, 5).Select(_ => new GenericTestee<Testee>()).ToList()};
+			yield return new object[] {Enumerable.Range(1, 5).Select(_ => new GenericTestee<NestedTestee>()).ToList()};
+			yield return new object[] {Enumerable.Range(1, 5).Select(_ => new GenericTestee<object>()).ToList()};
+		}
+	}
 }

--- a/HateoasNet/Abstractions/IHateoasContext.cs
+++ b/HateoasNet/Abstractions/IHateoasContext.cs
@@ -31,7 +31,7 @@ namespace HateoasNet.Abstractions
 
         /// <summary>
         ///   Adds or continues an <see cref="IHateoasResource{T}" /> configuration of
-        ///   <typeparamref name="T" /> using an <see cref="Action{IHateoasResource{T}}" /> action.
+        ///   <typeparamref name="T" /> using an <see cref="Action{T}" /> of <see cref="IHateoasResource{T}" /> action.
         /// </summary>
         /// <param name="resource">Action enabling configuration over the instance of IHateoasResource{T}.</param>
         /// <typeparam name="T">Target class for resource configuration.</typeparam>

--- a/HateoasNet/Abstractions/IHateoasContext.cs
+++ b/HateoasNet/Abstractions/IHateoasContext.cs
@@ -7,8 +7,8 @@ namespace HateoasNet.Abstractions
     /// <summary>
     ///   Represents the entry point for configuring HATEOAS integration.
     /// </summary>
-    public interface IHateoasContext : IDisposable
-    {
+    public interface IHateoasContext
+	{
         /// <summary>
         ///   Checks if <see cref="IHateoasContext" /> has a <see cref="IHateoasResource{T}" />
         ///   for T being <paramref name="type" />.
@@ -58,5 +58,5 @@ namespace HateoasNet.Abstractions
         /// <param name="assembly">Target assembly containing classes implementing <see cref="IHateoasResourceConfiguration{T}" />.</param>
         /// <returns>Current <see cref="IHateoasContext" /> instance.</returns>
         IHateoasContext ConfigureFromAssembly(Assembly assembly);
-    }
+	}
 }

--- a/HateoasNet/Abstractions/IHateoasLink.cs
+++ b/HateoasNet/Abstractions/IHateoasLink.cs
@@ -35,12 +35,12 @@ namespace HateoasNet.Abstractions
         ///   Checks if this <see cref="IHateoasLink" /> instance is applicable to output of <paramref name="resourceData" /> .
         /// </summary>
         /// <param name="resourceData">
-        ///   /// An object to be used as parameter of <see cref="IHateoasLink{T}.PredicateFunction" />
+        ///   /// An object to be used as parameter of <see cref="IHateoasLink{T}.Predicate" />
         ///   to evaluate predicate.
         /// </param>
         /// <returns>
         ///   <seealso cref="System.bool" /> if this <see cref="IHateoasLink" /> for <paramref name="resourceData" />
-        ///   passes <see cref="IHateoasLink{T}.PredicateFunction" /> for applicability.
+        ///   passes <see cref="IHateoasLink{T}.Predicate" /> for applicability.
         /// </returns>
         bool IsApplicable(object resourceData);
     }
@@ -60,7 +60,7 @@ namespace HateoasNet.Abstractions
         /// <summary>
         ///   An user defined predicate function to filter applicability of <see cref="IHateoasLink{T}" />.
         /// </summary>
-        Func<T, bool> PredicateFunction { get; }
+        Func<T, bool> Predicate { get; }
 
         /// <summary>
         ///   Receives an user defined function returning anonymous <see langword="object" /> for ease usage, converting it to

--- a/HateoasNet/Abstractions/IHateoasLink.cs
+++ b/HateoasNet/Abstractions/IHateoasLink.cs
@@ -1,6 +1,6 @@
-﻿using HateoasNet.Resources;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using HateoasNet.Resources;
 
 namespace HateoasNet.Abstractions
 {
@@ -8,7 +8,7 @@ namespace HateoasNet.Abstractions
     ///   Represents a configuration of HATEOAS link displayed to response output.
     /// </summary>
     public interface IHateoasLink
-    {
+	{
         /// <summary>
         ///   An endpoint Route Name assigned on an action method attribute.
         /// </summary>
@@ -43,14 +43,14 @@ namespace HateoasNet.Abstractions
         ///   passes <see cref="IHateoasLink{T}.Predicate" /> for applicability.
         /// </returns>
         bool IsApplicable(object resourceData);
-    }
+	}
 
     /// <summary>
     ///   Represents a <typeparamref name="T" /> configuration of HATEOAS link displayed to response output.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     public interface IHateoasLink<T> : IHateoasLink //where T : class
-    {
+	{
         /// <summary>
         ///   A framework function to generate <see cref="IDictionary{TKey, TValue}" /> of <see langword="string" />,
         ///   <see langword="object" /> representing the route values.
@@ -76,5 +76,5 @@ namespace HateoasNet.Abstractions
         /// <param name="predicate">Predicate function to filter applicability of <see cref="IHateoasLink{T}" />.</param>
         /// <returns>Current <see cref="IHateoasLink{T}" /> instance.</returns>
         IHateoasLink<T> HasConditional(Func<T, bool> predicate);
-    }
+	}
 }

--- a/HateoasNet/Abstractions/IHateoasResource.cs
+++ b/HateoasNet/Abstractions/IHateoasResource.cs
@@ -6,13 +6,13 @@ namespace HateoasNet.Abstractions
     ///   Represents a HATEOAS resource to be formatted associate with <see cref="IHateoasLink" /> configurations.
     /// </summary>
     public interface IHateoasResource
-    {
+	{
         /// <summary>
         ///   Gets all <see cref="IHateoasLink" /> associated with this <see cref="IHateoasResource" /> instance.
         /// </summary>
         /// <returns><see cref="IEnumerable{IHateoasLink}" /> representing Its Links.</returns>
         IEnumerable<IHateoasLink> GetLinks();
-    }
+	}
 
     /// <summary>
     ///   Represents a HATEOAS resource <typeparamref name="T" /> to be formatted associate with <see cref="IHateoasLink{T}" />
@@ -20,7 +20,7 @@ namespace HateoasNet.Abstractions
     /// </summary>
     /// <typeparam name="T"></typeparam>
     public interface IHateoasResource<T> : IHateoasResource where T : class
-    {
+	{
         /// <summary>
         ///   Adds our replaces an <see cref="IHateoasLink{T}" /> configuration with <paramref name="routeName" /> to this
         ///   <see cref="IHateoasResource{T}" /> instance.
@@ -31,5 +31,5 @@ namespace HateoasNet.Abstractions
         /// </param>
         /// <returns>A <see cref="IHateoasLink{T}" /> configuration generated with <paramref name="routeName" />.</returns>
         IHateoasLink<T> HasLink(string routeName);
-    }
+	}
 }

--- a/HateoasNet/Abstractions/IHateoasResourceConfiguration.cs
+++ b/HateoasNet/Abstractions/IHateoasResourceConfiguration.cs
@@ -5,11 +5,11 @@
     /// </summary>
     /// <typeparam name="T"></typeparam>
     public interface IHateoasResourceConfiguration<T> where T : class
-    {
+	{
         /// <summary>
         ///   Configure resource using implemented logic.
         /// </summary>
         /// <param name="resource">An <see cref="IHateoasResource{T}" /> instance to configure, generated internally.</param>
         void Configure(IHateoasResource<T> resource);
-    }
+	}
 }

--- a/HateoasNet/Abstractions/IHateoasSerializer.cs
+++ b/HateoasNet/Abstractions/IHateoasSerializer.cs
@@ -6,12 +6,12 @@ namespace HateoasNet.Abstractions
     ///   Represents a custom Serializer for  <see cref="Resource" /> formatted with HATEOAS.
     /// </summary>
     public interface IHateoasSerializer
-    {
+	{
         /// <summary>
         ///   Serializes a formatted instance inheriting from <see cref="Resource" />.
         /// </summary>
         /// <param name="resource">The formatted instance inheriting from <see cref="Resource" />.</param>
         /// <returns>Json <see langword="string" /> representing formatted <see cref="Resource" /> output.</returns>
         string SerializeResource(Resource resource);
-    }
+	}
 }

--- a/HateoasNet/Abstractions/IPagination.cs
+++ b/HateoasNet/Abstractions/IPagination.cs
@@ -7,29 +7,29 @@ namespace HateoasNet.Abstractions
     ///   Represents an <see cref="ICollection" /> paginated.
     /// </summary>
     public interface IPagination
-    {
-        long Count { get; }
-        int PageSize { get; }
-        int Page { get; }
-        int Pages { get; }
+	{
+		long Count { get; }
+		int PageSize { get; }
+		int Page { get; }
+		int Pages { get; }
 
         /// <summary>
         ///   Gets the paginated <see cref="ICollection" /> items as <see cref="IEnumerable" />.
         /// </summary>
         /// <returns></returns>
         IEnumerable GetItems();
-    }
+	}
 
     /// <summary>
     ///   Represents an <see cref="ICollection{T}" /> paginated.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     public interface IPagination<out T> : IPagination
-    {
+	{
         /// <summary>
         ///   Gets paginated <see cref="ICollection{T}" /> items as <see cref="IEnumerable{T}" />.
         /// </summary>
         /// <returns>paginated <see cref="ICollection{T}" /> items as <see cref="IEnumerable{T}" />.</returns>
         new IEnumerable<T> GetItems();
-    }
+	}
 }

--- a/HateoasNet/Abstractions/IPagination.cs
+++ b/HateoasNet/Abstractions/IPagination.cs
@@ -17,7 +17,7 @@ namespace HateoasNet.Abstractions
         ///   Gets the paginated <see cref="ICollection" /> items as <see cref="IEnumerable" />.
         /// </summary>
         /// <returns></returns>
-        IEnumerable GetEnumeration();
+        IEnumerable GetItems();
     }
 
     /// <summary>
@@ -27,8 +27,9 @@ namespace HateoasNet.Abstractions
     public interface IPagination<out T> : IPagination
     {
         /// <summary>
-        ///   The paginated <see cref="ICollection{T}" /> items as <see cref="IEnumerable{T}" />.
+        ///   Gets paginated <see cref="ICollection{T}" /> items as <see cref="IEnumerable{T}" />.
         /// </summary>
-        IEnumerable<T> Data { get; }
+        /// <returns>paginated <see cref="ICollection{T}" /> items as <see cref="IEnumerable{T}" />.</returns>
+        new IEnumerable<T> GetItems();
     }
 }

--- a/HateoasNet/Abstractions/IResourceFactory.cs
+++ b/HateoasNet/Abstractions/IResourceFactory.cs
@@ -1,6 +1,6 @@
-﻿using HateoasNet.Resources;
-using System;
+﻿using System;
 using System.Collections;
+using HateoasNet.Resources;
 
 namespace HateoasNet.Abstractions
 {
@@ -8,7 +8,7 @@ namespace HateoasNet.Abstractions
     ///   Represents a Factory for creation of formatted <see cref="Resource" /> output instances.
     /// </summary>
     public interface IResourceFactory
-    {
+	{
         /// <summary>
         ///   Creates a formatted <see cref="SingleResource" /> using <see cref="IHateoasResource{T}" /> configuration
         ///   of <paramref name="type" /> with <paramref name="source" /> as original value.
@@ -36,5 +36,5 @@ namespace HateoasNet.Abstractions
         /// <param name="type">type parameter of <see cref="IHateoasResource{T}" /> configuration.</param>
         /// <returns>A formatted <see cref="PaginationResource" /> instance.</returns>
         PaginationResource Create(IPagination source, Type type);
-    }
+	}
 }

--- a/HateoasNet/Abstractions/IResourceLinkFactory.cs
+++ b/HateoasNet/Abstractions/IResourceLinkFactory.cs
@@ -1,5 +1,5 @@
-﻿using HateoasNet.Resources;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using HateoasNet.Resources;
 
 namespace HateoasNet.Abstractions
 {
@@ -7,7 +7,7 @@ namespace HateoasNet.Abstractions
     ///   Represents a Factory for creation of <see cref="ResourceLink" /> instances.
     /// </summary>
     public interface IResourceLinkFactory
-    {
+	{
         /// <summary>
         ///   Creates a HATEOAS <see cref="ResourceLink" /> using <paramref name="rel" />
         ///   with <paramref name="routeValues" /> to discover route Url and HTTP method.
@@ -17,9 +17,10 @@ namespace HateoasNet.Abstractions
         ///   <para>see also <seealso cref="IHateoasLink.RouteName" />.</para>
         /// </param>
         /// <param name="routeValues">
-        ///   The <see cref="IDictionary{TKey,TValue}" /> of <see langword="string" />, <see langword="object" /> holding route values.
+        ///   The <see cref="IDictionary{TKey,TValue}" /> of <see langword="string" />, <see langword="object" /> holding route
+        ///   values.
         /// </param>
         /// <returns>The generated <see cref="ResourceLink" /> instance for HATEOAS output.</returns>
         ResourceLink Create(string rel, IDictionary<string, object> routeValues);
-    }
+	}
 }

--- a/HateoasNet/Configurations/HateoasContext.cs
+++ b/HateoasNet/Configurations/HateoasContext.cs
@@ -8,109 +8,117 @@ using System.Runtime.InteropServices;
 
 namespace HateoasNet.Configurations
 {
-    /// <inheritdoc cref="IHateoasContext" />
-    public sealed class HateoasContext : IHateoasContext
-    {
-        internal HateoasContext()
-        {
-        }
+	/// <inheritdoc cref="IHateoasContext" />
+	public sealed class HateoasContext : IHateoasContext
+	{
+		internal HateoasContext()
+		{
+		}
 
-        private readonly SafeHandle _handle = new SafeFileHandle(IntPtr.Zero, true);
-        private readonly Dictionary<Type, IHateoasResource> _resources = new Dictionary<Type, IHateoasResource>();
-        private bool _disposed;
+		private readonly SafeHandle _handle = new SafeFileHandle(IntPtr.Zero, true);
+		private readonly Dictionary<Type, IHateoasResource> _resources = new Dictionary<Type, IHateoasResource>();
+		private readonly string _resourceConfigurationTypeName = typeof(IHateoasResourceConfiguration<>).Name;
+		private bool _disposed;
 
-        public IEnumerable<IHateoasLink> GetApplicableLinks(Type type, object value)
-        {
-            if (type == null) throw new ArgumentNullException(nameof(type));
-            if (value == null) throw new ArgumentNullException(nameof(value));
+		public IEnumerable<IHateoasLink> GetApplicableLinks(Type type, object value)
+		{
+			if (type == null) throw new ArgumentNullException(nameof(type));
+			if (value == null) throw new ArgumentNullException(nameof(value));
 
-            return _resources.TryGetValue(type, out var configuredResource)
-                ? configuredResource?.GetLinks().Where(link => link.IsApplicable(value)).ToList()
-                : new List<IHateoasLink>();
-        }
+			return _resources.TryGetValue(type, out var configuredResource)
+				? configuredResource?.GetLinks().Where(link => link.IsApplicable(value)).ToList()
+				: new List<IHateoasLink>();
+		}
 
-        public bool HasResource(Type type)
-        {
-            return _resources.ContainsKey(type);
-        }
+		public bool HasResource(Type type)
+		{
+			return _resources.ContainsKey(type);
+		}
 
-        public IHateoasContext Configure<T>(Action<IHateoasResource<T>> resource) where T : class
-        {
-            if (resource == null) throw new ArgumentNullException(nameof(resource));
+		public IHateoasContext Configure<T>(Action<IHateoasResource<T>> resource) where T : class
+		{
+			if (resource == null) throw new ArgumentNullException(nameof(resource));
 
-            resource(GetOrInsert<T>());
+			resource(GetOrInsert<T>());
 
-            return this;
-        }
+			return this;
+		}
 
-        public IHateoasContext ApplyConfiguration<T>(IHateoasResourceConfiguration<T> configuration) where T : class
-        {
-            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
+		public IHateoasContext ApplyConfiguration<T>(IHateoasResourceConfiguration<T> configuration) where T : class
+		{
+			if (configuration == null) throw new ArgumentNullException(nameof(configuration));
 
-            configuration.Configure(GetOrInsert<T>());
+			configuration.Configure(GetOrInsert<T>());
 
-            return this;
-        }
+			return this;
+		}
 
-        public IHateoasContext ConfigureFromAssembly(Assembly assembly)
-        {
-            if (assembly == null) throw new ArgumentNullException(nameof(assembly));
+		public IHateoasContext ConfigureFromAssembly(Assembly assembly)
+		{
+			if (assembly == null) throw new ArgumentNullException(nameof(assembly));
 
-            var resourceConfigurationName = typeof(IHateoasResourceConfiguration<>).Name;
+			var builders = assembly.GetTypes()
+			                       .Where(t => t.GetInterfaces().Any(i => i.Name.Contains(_resourceConfigurationTypeName)))
+			                       .ToList();
 
-            var builders = assembly.GetTypes()
-                                   .Where(t => t.GetInterfaces().Any(i => i.Name.Contains(resourceConfigurationName)))
-                                   .ToList();
+			if (!builders.Any()) throw new TargetException(GetTargetExceptionMessage(assembly.FullName));
 
-            if (!builders.Any())
-                throw new
-                    TargetException($"No implementation of '{resourceConfigurationName}' found in assembly '{assembly.FullName}'.");
+			builders.ForEach(builderType =>
+			{
+				var interfaceType = builderType.GetInterfaces().Single();
+				var targetType = interfaceType.GetGenericArguments().First();
+				var hateoasMap = GetOrInsert(targetType);
+				var builder = Activator.CreateInstance(builderType);
+				var buildMethod = builderType.GetMethod(nameof(IHateoasResourceConfiguration<object>.Configure));
+				buildMethod?.Invoke(builder, new object[] {hateoasMap});
+			});
 
-            builders.ForEach(builderType =>
-            {
-                var interfaceType = builderType.GetInterfaces().Single();
-                var targetType = interfaceType.GetGenericArguments().First();
-                var hateoasMap = GetOrInsert(targetType);
-                var builder = Activator.CreateInstance(builderType);
-                var buildMethod = builderType.GetMethod(nameof(IHateoasResourceConfiguration<object>.Configure));
-                buildMethod?.Invoke(builder, new object[] { hateoasMap });
-            });
+			return this;
+		}
 
-            return this;
-        }
+		internal IHateoasResource<T> GetOrInsert<T>() where T : class
+		{
+			var targetType = typeof(T);
 
-        internal IHateoasResource<T> GetOrInsert<T>() where T : class
-        {
-            var targetType = typeof(T);
+			if (!_resources.ContainsKey(targetType)) _resources.Add(targetType, new HateoasResource<T>());
 
-            if (!_resources.ContainsKey(targetType)) _resources.Add(targetType, new HateoasResource<T>());
+			return _resources[targetType] as IHateoasResource<T>;
+		}
 
-            return _resources[targetType] as IHateoasResource<T>;
-        }
+		internal IHateoasResource GetOrInsert(Type targetType)
+		{
+			if (_resources.ContainsKey(targetType)) return _resources[targetType];
 
-        internal IHateoasResource GetOrInsert(Type targetType)
-        {
-            if (_resources.ContainsKey(targetType)) return _resources[targetType];
+			var hateoasMapType = typeof(HateoasResource<>).MakeGenericType(targetType);
+			_resources.Add(targetType, Activator.CreateInstance(hateoasMapType, true) as IHateoasResource);
 
-            var hateoasMapType = typeof(HateoasResource<>).MakeGenericType(targetType);
-            _resources.Add(targetType, Activator.CreateInstance(hateoasMapType, true) as IHateoasResource);
+			return _resources[targetType];
+		}
 
-            return _resources[targetType];
-        }
+		private string GetTargetExceptionMessage(string assemblyName)
+		{
+			return $"No implementation of '{_resourceConfigurationTypeName}' found in assembly '{assemblyName}'.";
+		}
 
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
+		private void Dispose(bool disposing)
+		{
+			if (_disposed) return;
 
-        private void Dispose(bool disposing)
-        {
-            if (_disposed) return;
+			if (disposing)
+				_handle?.Dispose();
 
-            if (!disposing) return;
-            _handle.Dispose();
-            _disposed = true;
-        }
-    }
+			_disposed = true;
+		}
+
+		~HateoasContext()
+		{
+			Dispose(false);
+		}
+
+		public void Dispose()
+		{
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
+	}
 }

--- a/HateoasNet/Configurations/HateoasLink.cs
+++ b/HateoasNet/Configurations/HateoasLink.cs
@@ -1,54 +1,54 @@
-﻿using HateoasNet.Abstractions;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using HateoasNet.Abstractions;
 
 namespace HateoasNet.Configurations
 {
-    /// <inheritdoc cref="IHateoasLink" />
-    public sealed class HateoasLink<T> : IHateoasLink<T> where T : class
-    {
-        internal HateoasLink(string routeName) : this(routeName, e => null, e => true)
-        {
-        }
+	/// <inheritdoc cref="IHateoasLink" />
+	public sealed class HateoasLink<T> : IHateoasLink<T> where T : class
+	{
+		internal HateoasLink(string routeName) : this(routeName, e => null, e => true)
+		{
+		}
 
-        private HateoasLink(string routeName,
-                            Func<T, IDictionary<string, object>> routeDictionaryFunction,
-                            Func<T, bool> predicateFunction)
-        {
-            RouteName = routeName;
-            RouteDictionaryFunction = routeDictionaryFunction;
-            Predicate = predicateFunction;
-        }
+		private HateoasLink(string routeName,
+		                    Func<T, IDictionary<string, object>> routeDictionaryFunction,
+		                    Func<T, bool> predicate)
+		{
+			RouteName = routeName;
+			RouteDictionaryFunction = routeDictionaryFunction;
+			Predicate = predicate;
+		}
 
-        public string RouteName { get; }
-        public Func<T, bool> Predicate { get; private set; }
-        public Func<T, IDictionary<string, object>> RouteDictionaryFunction { get; private set; }
+		public string RouteName { get; }
+		public Func<T, bool> Predicate { get; private set; }
+		public Func<T, IDictionary<string, object>> RouteDictionaryFunction { get; private set; }
 
-        public IDictionary<string, object> GetRouteDictionary(object resourceData)
-        {
-            if (resourceData == null) throw new ArgumentNullException(nameof(resourceData));
+		public IDictionary<string, object> GetRouteDictionary(object resourceData)
+		{
+			if (resourceData == null) throw new ArgumentNullException(nameof(resourceData));
 
-            return RouteDictionaryFunction((T)resourceData);
-        }
+			return RouteDictionaryFunction((T) resourceData);
+		}
 
-        public bool IsApplicable(object resourceData)
-        {
-            if (resourceData == null) throw new ArgumentNullException(nameof(resourceData));
+		public bool IsApplicable(object resourceData)
+		{
+			if (resourceData == null) throw new ArgumentNullException(nameof(resourceData));
 
-            return Predicate((T)resourceData);
-        }
+			return Predicate((T) resourceData);
+		}
 
-        public IHateoasLink<T> HasRouteData(Func<T, object> routeDataFunction)
-        {
-            if (routeDataFunction == null) throw new ArgumentNullException(nameof(routeDataFunction));
-            RouteDictionaryFunction = source => routeDataFunction(source).ToRouteDictionary();
-            return this;
-        }
+		public IHateoasLink<T> HasRouteData(Func<T, object> routeDataFunction)
+		{
+			if (routeDataFunction == null) throw new ArgumentNullException(nameof(routeDataFunction));
+			RouteDictionaryFunction = source => routeDataFunction(source).ToRouteDictionary();
+			return this;
+		}
 
-        public IHateoasLink<T> HasConditional(Func<T, bool> predicate)
-        {
-            Predicate = predicate ?? throw new ArgumentNullException(nameof(predicate));
-            return this;
-        }
-    }
+		public IHateoasLink<T> HasConditional(Func<T, bool> predicate)
+		{
+			Predicate = predicate ?? throw new ArgumentNullException(nameof(predicate));
+			return this;
+		}
+	}
 }

--- a/HateoasNet/Configurations/HateoasLink.cs
+++ b/HateoasNet/Configurations/HateoasLink.cs
@@ -17,11 +17,11 @@ namespace HateoasNet.Configurations
         {
             RouteName = routeName;
             RouteDictionaryFunction = routeDictionaryFunction;
-            PredicateFunction = predicateFunction;
+            Predicate = predicateFunction;
         }
 
         public string RouteName { get; }
-        public Func<T, bool> PredicateFunction { get; private set; }
+        public Func<T, bool> Predicate { get; private set; }
         public Func<T, IDictionary<string, object>> RouteDictionaryFunction { get; private set; }
 
         public IDictionary<string, object> GetRouteDictionary(object resourceData)
@@ -35,7 +35,7 @@ namespace HateoasNet.Configurations
         {
             if (resourceData == null) throw new ArgumentNullException(nameof(resourceData));
 
-            return PredicateFunction((T)resourceData);
+            return Predicate((T)resourceData);
         }
 
         public IHateoasLink<T> HasRouteData(Func<T, object> routeDataFunction)
@@ -47,7 +47,7 @@ namespace HateoasNet.Configurations
 
         public IHateoasLink<T> HasConditional(Func<T, bool> predicate)
         {
-            PredicateFunction = predicate ?? throw new ArgumentNullException(nameof(predicate));
+            Predicate = predicate ?? throw new ArgumentNullException(nameof(predicate));
             return this;
         }
     }

--- a/HateoasNet/Configurations/HateoasResource.cs
+++ b/HateoasNet/Configurations/HateoasResource.cs
@@ -1,31 +1,31 @@
-﻿using HateoasNet.Abstractions;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using HateoasNet.Abstractions;
 
 namespace HateoasNet.Configurations
 {
-    /// <inheritdoc cref="IHateoasResource" />
-    public sealed class HateoasResource<T> : IHateoasResource<T> where T : class
-    {
-        private readonly Dictionary<string, IHateoasLink> _hateoasLinks = new Dictionary<string, IHateoasLink>();
+	/// <inheritdoc cref="IHateoasResource" />
+	public sealed class HateoasResource<T> : IHateoasResource<T> where T : class
+	{
+		private readonly Dictionary<string, IHateoasLink> _hateoasLinks = new Dictionary<string, IHateoasLink>();
 
-        internal HateoasResource()
-        {
-        }
+		internal HateoasResource()
+		{
+		}
 
-        public IEnumerable<IHateoasLink> GetLinks()
-        {
-            return _hateoasLinks.Values.ToList();
-        }
+		public IEnumerable<IHateoasLink> GetLinks()
+		{
+			return _hateoasLinks.Values.ToList();
+		}
 
-        public IHateoasLink<T> HasLink(string routeName)
-        {
-            if (string.IsNullOrWhiteSpace(routeName)) throw new ArgumentNullException(nameof(routeName));
+		public IHateoasLink<T> HasLink(string routeName)
+		{
+			if (string.IsNullOrWhiteSpace(routeName)) throw new ArgumentNullException(nameof(routeName));
 
-            _hateoasLinks[routeName] = new HateoasLink<T>(routeName);
+			_hateoasLinks[routeName] = new HateoasLink<T>(routeName);
 
-            return _hateoasLinks[routeName] as IHateoasLink<T>;
-        }
-    }
+			return _hateoasLinks[routeName] as IHateoasLink<T>;
+		}
+	}
 }

--- a/HateoasNet/Configurations/MappingExtensions.cs
+++ b/HateoasNet/Configurations/MappingExtensions.cs
@@ -7,21 +7,26 @@ using System.Reflection;
 
 namespace HateoasNet.Configurations
 {
-    public static class MappingExtensions
-    {
-        public static IDictionary<string, object> ToRouteDictionary(this object source)
-        {
-            if (source is IEnumerable) return new Dictionary<string, object>();
+	public static class MappingExtensions
+	{
+		public static IDictionary<string, object> ToRouteDictionary(this object source)
+		{
+			if (source is IEnumerable) return new Dictionary<string, object>();
 
-            string NameFunction(MemberInfo info) => info.Name;
+			string NameFunction(MemberInfo info)
+			{
+				return info.Name;
+			}
 
-            object ValueFunction(PropertyInfo info) =>
-                info.GetValue(source, BindingFlags.Public, null, null, CultureInfo.InvariantCulture);
+			object ValueFunction(PropertyInfo info)
+			{
+				return info.GetValue(source, BindingFlags.Public, null, null, CultureInfo.InvariantCulture);
+			}
 
-            return source.GetType()
-                         .GetProperties()
-                         .Where(x => x.CanRead && x.MemberType == MemberTypes.Property)
-                         .ToDictionary(NameFunction, ValueFunction, StringComparer.OrdinalIgnoreCase);
-        }
-    }
+			return source.GetType()
+			             .GetProperties()
+			             .Where(x => x.CanRead && x.MemberType == MemberTypes.Property)
+			             .ToDictionary(NameFunction, ValueFunction, StringComparer.OrdinalIgnoreCase);
+		}
+	}
 }

--- a/HateoasNet/Factories/ResourceFactory.cs
+++ b/HateoasNet/Factories/ResourceFactory.cs
@@ -35,7 +35,7 @@ namespace HateoasNet.Factories
 
         public PaginationResource Create(IPagination source, Type type)
         {
-            var singleResources = ToEnumerableOfResources(source.GetEnumeration(), type);
+            var singleResources = ToEnumerableOfResources(source.GetItems(), type);
             var paginationResource = new PaginationResource(singleResources, source.Count, source.PageSize, source.Page);
             BuildResourceLinks(paginationResource, source, type);
             return paginationResource;
@@ -49,12 +49,12 @@ namespace HateoasNet.Factories
         /// <param name="type">
         ///   type parameter of <see cref="IHateoasLink{T}" /> configuration to builds the <see cref="Resource.Links" />.
         /// </param>
-        internal void BuildResourceLinks(Resource resource, object data, Type type)
+        internal void BuildResourceLinks(Resource resource, object value, Type type)
         {
-            foreach (var hateoasLink in _hateoasConfiguration.GetApplicableLinks(type, data))
+            foreach (var hateoasLink in _hateoasConfiguration.GetApplicableLinks(type, value))
             {
                 var createdLink =
-                    _resourceLinkFactory.Create(hateoasLink.RouteName, hateoasLink.GetRouteDictionary(data));
+                    _resourceLinkFactory.Create(hateoasLink.RouteName, hateoasLink.GetRouteDictionary(value));
 
                 resource.Links.Add(createdLink);
             }

--- a/HateoasNet/Factories/ResourceFactory.cs
+++ b/HateoasNet/Factories/ResourceFactory.cs
@@ -1,45 +1,45 @@
-﻿using HateoasNet.Abstractions;
-using HateoasNet.Resources;
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using HateoasNet.Abstractions;
+using HateoasNet.Resources;
 
 namespace HateoasNet.Factories
 {
-    /// <inheritdoc cref="IResourceFactory" />
-    public sealed class ResourceFactory : IResourceFactory
-    {
-        private readonly IHateoasContext _hateoasConfiguration;
-        private readonly IResourceLinkFactory _resourceLinkFactory;
+	/// <inheritdoc cref="IResourceFactory" />
+	public sealed class ResourceFactory : IResourceFactory
+	{
+		private readonly IHateoasContext _hateoasConfiguration;
+		private readonly IResourceLinkFactory _resourceLinkFactory;
 
-        public ResourceFactory(IHateoasContext hateoasConfiguration, IResourceLinkFactory resourceLinkFactory)
-        {
-            _hateoasConfiguration = hateoasConfiguration;
-            _resourceLinkFactory = resourceLinkFactory;
-        }
+		public ResourceFactory(IHateoasContext hateoasConfiguration, IResourceLinkFactory resourceLinkFactory)
+		{
+			_hateoasConfiguration = hateoasConfiguration;
+			_resourceLinkFactory = resourceLinkFactory;
+		}
 
-        public SingleResource Create(object source, Type type)
-        {
-            var singleResource = new SingleResource(source);
-            BuildResourceLinks(singleResource, source, type);
-            return singleResource;
-        }
+		public SingleResource Create(object source, Type type)
+		{
+			var singleResource = new SingleResource(source);
+			BuildResourceLinks(singleResource, source, type);
+			return singleResource;
+		}
 
-        public EnumerableResource Create(IEnumerable source, Type type)
-        {
-            var enumerableResource = new EnumerableResource(ToEnumerableOfResources(source, type));
-            BuildResourceLinks(enumerableResource, source, type);
-            return enumerableResource;
-        }
+		public EnumerableResource Create(IEnumerable source, Type type)
+		{
+			var enumerableResource = new EnumerableResource(ToEnumerableOfResources(source, type));
+			BuildResourceLinks(enumerableResource, source, type);
+			return enumerableResource;
+		}
 
-        public PaginationResource Create(IPagination source, Type type)
-        {
-            var singleResources = ToEnumerableOfResources(source.GetItems(), type);
-            var paginationResource = new PaginationResource(singleResources, source.Count, source.PageSize, source.Page);
-            BuildResourceLinks(paginationResource, source, type);
-            return paginationResource;
-        }
+		public PaginationResource Create(IPagination source, Type type)
+		{
+			var singleResources = ToEnumerableOfResources(source.GetItems(), type);
+			var paginationResource = new PaginationResource(singleResources, source.Count, source.PageSize, source.Page);
+			BuildResourceLinks(paginationResource, source, type);
+			return paginationResource;
+		}
 
         /// <summary>
         ///   Builds the <see cref="Resource.Links" /> collection for created <see cref="Resource" />.
@@ -50,19 +50,19 @@ namespace HateoasNet.Factories
         ///   type parameter of <see cref="IHateoasLink{T}" /> configuration to builds the <see cref="Resource.Links" />.
         /// </param>
         internal void BuildResourceLinks(Resource resource, object value, Type type)
-        {
-            foreach (var hateoasLink in _hateoasConfiguration.GetApplicableLinks(type, value))
-            {
-                var createdLink =
-                    _resourceLinkFactory.Create(hateoasLink.RouteName, hateoasLink.GetRouteDictionary(value));
+		{
+			foreach (var hateoasLink in _hateoasConfiguration.GetApplicableLinks(type, value))
+			{
+				var createdLink =
+					_resourceLinkFactory.Create(hateoasLink.RouteName, hateoasLink.GetRouteDictionary(value));
 
-                resource.Links.Add(createdLink);
-            }
-        }
+				resource.Links.Add(createdLink);
+			}
+		}
 
-        internal IEnumerable<Resource> ToEnumerableOfResources(IEnumerable source, Type type)
-        {
-            return from object item in source select Create(item, type.GetGenericArguments().First());
-        }
-    }
+		internal IEnumerable<Resource> ToEnumerableOfResources(IEnumerable source, Type type)
+		{
+			return from object item in source select Create(item, type.GetGenericArguments().First());
+		}
+	}
 }

--- a/HateoasNet/HateoasNet.csproj
+++ b/HateoasNet/HateoasNet.csproj
@@ -3,21 +3,19 @@
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;netcoreapp3.1;net472;</TargetFrameworks>
         <LangVersion>8.0</LangVersion>
-        <PackageVersion>1.0.0-alpha</PackageVersion>
         <Title>HateoasNet</Title>
+        <Version>$(Version)</Version>
+        <VersionSuffix>$(VersionSuffix)</VersionSuffix>
         <Authors>icarotorres</Authors>
-        <Summary>.Net Standard Library with base abstractions and common implementations for supporting HateoasNet packages.</Summary>
+        <PackageSummary>.Net Standard Library with base abstractions and common implementations for supporting HateoasNet packages.</PackageSummary>
         <Description>.Net Standard Library with base abstractions and common implementations for supporting HateoasNet packages.</Description>
         <PackageProjectUrl>https://github.com/icarotorres/HateoasNet</PackageProjectUrl>
         <PackageLicense>https://github.com/IcaroTorres/HateoasNet/blob/master/LICENSE</PackageLicense>
         <RepositoryUrl>https://github.com/icarotorres/HateoasNet.git</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageTags>json, hateoas, api-rest, hateoas-response, hateoasnet</PackageTags>
-        <Version>1.0.0-alpha</Version>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageTypes>
-          <PackageType name="Dependency" />
-        </PackageTypes>
+        <PackageTypes>dependency</PackageTypes>
         <PackageReleaseNotes>
           Features:
 
@@ -29,7 +27,7 @@
 
           visit project repo to contribute: https://github.com/icarotorres/HateoasNet.git
         </PackageReleaseNotes>
-      
+
     </PropertyGroup>
 
     <ItemGroup>

--- a/HateoasNet/Resources/EnumerableResource.cs
+++ b/HateoasNet/Resources/EnumerableResource.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace HateoasNet.Resources
@@ -6,28 +7,31 @@ namespace HateoasNet.Resources
     /// <summary>
     ///   Represents a formatted enumeration wrapper of <see cref="Resource" /> items.
     /// </summary>
-    [System.Serializable]
-    public class EnumerableResource : Resource
-    {
-        public EnumerableResource(IEnumerable<Resource> data) : base(data)
-        {
-            _items = data.ToList();
-        }
+    [Serializable]
+	public class EnumerableResource : Resource
+	{
+		private readonly List<Resource> _items;
 
-        private readonly List<Resource> _items;
+		public EnumerableResource(IEnumerable<Resource> data) : base(data)
+		{
+			_items = data.ToList();
+		}
 
 
         /// <summary>
-        ///   The <see cref="Resource.Data"/> property overriden with actual value being
-        ///   <see cref="IEnumerable{T}" /> of <see cref="Resource"/> as <see langword="object"/>.
+        ///   The <see cref="Resource.Data" /> property overriden with actual value being
+        ///   <see cref="IEnumerable{T}" /> of <see cref="Resource" /> as <see langword="object" />.
         /// </summary>
         public override object Data => GetItems();
 
 
         /// <summary>
-        /// Returns the items as an <see cref="IEnumerable{T}" /> of <see cref="Resource"/>.
+        ///   Returns the items as an <see cref="IEnumerable{T}" /> of <see cref="Resource" />.
         /// </summary>
         /// <returns></returns>
-        public virtual IEnumerable<Resource> GetItems() => _items;
-    }
+        public virtual IEnumerable<Resource> GetItems()
+		{
+			return _items;
+		}
+	}
 }

--- a/HateoasNet/Resources/EnumerableResource.cs
+++ b/HateoasNet/Resources/EnumerableResource.cs
@@ -4,21 +4,30 @@ using System.Linq;
 namespace HateoasNet.Resources
 {
     /// <summary>
-    ///   Represents an formatted enumeration wrapper of <see cref="Resource" /> wrapper items which inherit from
-    ///   <see cref="Resource" />.
+    ///   Represents a formatted enumeration wrapper of <see cref="Resource" /> items.
     /// </summary>
+    [System.Serializable]
     public class EnumerableResource : Resource
     {
         public EnumerableResource(IEnumerable<Resource> data) : base(data)
         {
-            EnumerableData = data.ToList();
+            _items = data.ToList();
         }
 
-        internal IEnumerable<Resource> EnumerableData { get; }
+        private readonly List<Resource> _items;
+
 
         /// <summary>
-        ///   The <see cref="Resource.Data"/> property overriden to return <see cref="IEnumerable{Resource}" />.
+        ///   The <see cref="Resource.Data"/> property overriden with actual value being
+        ///   <see cref="IEnumerable{T}" /> of <see cref="Resource"/> as <see langword="object"/>.
         /// </summary>
-        public override object Data => EnumerableData;
+        public override object Data => GetItems();
+
+
+        /// <summary>
+        /// Returns the items as an <see cref="IEnumerable{T}" /> of <see cref="Resource"/>.
+        /// </summary>
+        /// <returns></returns>
+        public virtual IEnumerable<Resource> GetItems() => _items;
     }
 }

--- a/HateoasNet/Resources/Pagination.cs
+++ b/HateoasNet/Resources/Pagination.cs
@@ -1,29 +1,30 @@
 ﻿using HateoasNet.Abstractions;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace HateoasNet.Resources
 {
     /// <inheritdoc cref="IPagination{T}" />
+    [System.Serializable]
     public class Pagination<T> : IPagination<T> where T : class
     {
         public Pagination(IEnumerable<T> data, long count, int pageSize, int page = 1)
         {
-            Data = data;
+            Items = data.ToList();
             Count = count;
             PageSize = pageSize;
             Page = page;
         }
 
-        public IEnumerable GetEnumeration()
-        {
-            return Data;
-        }
+        public virtual IEnumerable<T> Items { get; }
+        public virtual long Count { get; }
+        public virtual int PageSize { get; }
+        public virtual int Page { get; }
+        public virtual int Pages => (int)(Count == 0 ? 1 : (Count + PageSize - 1) / PageSize);
 
-        public IEnumerable<T> Data { get; }
-        public long Count { get; }
-        public int PageSize { get; }
-        public int Page { get; }
-        public int Pages => (int)(Count == 0 ? 1 : (Count + PageSize - 1) / PageSize);
+        public virtual IEnumerable<T> GetItems() => Items;
+
+        IEnumerable IPagination.GetItems() => GetItems();
     }
 }

--- a/HateoasNet/Resources/Pagination.cs
+++ b/HateoasNet/Resources/Pagination.cs
@@ -1,30 +1,37 @@
-﻿using HateoasNet.Abstractions;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using HateoasNet.Abstractions;
 
 namespace HateoasNet.Resources
 {
-    /// <inheritdoc cref="IPagination{T}" />
-    [System.Serializable]
-    public class Pagination<T> : IPagination<T> where T : class
-    {
-        public Pagination(IEnumerable<T> data, long count, int pageSize, int page = 1)
-        {
-            Items = data.ToList();
-            Count = count;
-            PageSize = pageSize;
-            Page = page;
-        }
+	/// <inheritdoc cref="IPagination{T}" />
+	[Serializable]
+	public class Pagination<T> : IPagination<T> where T : class
+	{
+		public Pagination(IEnumerable<T> data, long count, int pageSize, int page = 1)
+		{
+			Items = data.ToList();
+			Count = count;
+			PageSize = pageSize;
+			Page = page;
+		}
 
-        public virtual IEnumerable<T> Items { get; }
-        public virtual long Count { get; }
-        public virtual int PageSize { get; }
-        public virtual int Page { get; }
-        public virtual int Pages => (int)(Count == 0 ? 1 : (Count + PageSize - 1) / PageSize);
+		public virtual IEnumerable<T> Items { get; }
+		public virtual long Count { get; }
+		public virtual int PageSize { get; }
+		public virtual int Page { get; }
+		public virtual int Pages => (int) (Count == 0 ? 1 : (Count + PageSize - 1) / PageSize);
 
-        public virtual IEnumerable<T> GetItems() => Items;
+		public virtual IEnumerable<T> GetItems()
+		{
+			return Items;
+		}
 
-        IEnumerable IPagination.GetItems() => GetItems();
-    }
+		IEnumerable IPagination.GetItems()
+		{
+			return GetItems();
+		}
+	}
 }

--- a/HateoasNet/Resources/PaginationResource.cs
+++ b/HateoasNet/Resources/PaginationResource.cs
@@ -1,47 +1,49 @@
-﻿using HateoasNet.Abstractions;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using HateoasNet.Abstractions;
 
 namespace HateoasNet.Resources
 {
     /// <summary>
     ///   Represents a formatted pagination wrapper of <see cref="Resource" /> items.
     /// </summary>
-    [System.Serializable]
-    public class PaginationResource : Resource, IPagination<Resource>
-    {
-        public PaginationResource(IEnumerable<Resource> items, long count, int pageSize, int page) : base(items)
-        {
-            _items = items.ToList();
-            Count = count;
-            PageSize = pageSize;
-            Page = page;
-        }
+    [Serializable]
+	public class PaginationResource : Resource, IPagination<Resource>
+	{
+		private readonly List<Resource> _items;
 
-        private readonly List<Resource> _items;
+		public PaginationResource(IEnumerable<Resource> items, long count, int pageSize, int page) : base(items)
+		{
+			_items = items.ToList();
+			Count = count;
+			PageSize = pageSize;
+			Page = page;
+		}
 
         /// <summary>
-        ///   The <see cref="Resource.Data"/> property overriden with actual value being
-        ///   <see cref="IEnumerable{T}" /> of <see cref="Resource"/> items as <see langword="object"/>.
+        ///   The <see cref="Resource.Data" /> property overriden with actual value being
+        ///   <see cref="IEnumerable{T}" /> of <see cref="Resource" /> items as <see langword="object" />.
         /// </summary>
         public override object Data => GetItems();
-        public virtual int InPage => GetItems().Count();
-        public virtual int Page { get; }
-        public virtual int PageSize { get; }
-        public virtual long Count { get; }
-        public virtual int Pages => (int)(Count == 0 ? 1 : (Count + PageSize - 1) / PageSize);
 
-        /// <inheritdoc cref="IPagination{Resource}.GetItems"/>
+		public virtual int InPage => GetItems().Count();
+		public virtual int Page { get; }
+		public virtual int PageSize { get; }
+		public virtual long Count { get; }
+		public virtual int Pages => (int) (Count == 0 ? 1 : (Count + PageSize - 1) / PageSize);
+
+        /// <inheritdoc cref="IPagination{Resource}.GetItems" />
         public virtual IEnumerable<Resource> GetItems()
-        {
-            return _items;
-        }
+		{
+			return _items;
+		}
 
-        /// <inheritdoc cref="IPagination.GetItems"/>
+        /// <inheritdoc cref="IPagination.GetItems" />
         IEnumerable IPagination.GetItems()
-        {
-            return _items;
-        }
-    }
+		{
+			return _items;
+		}
+	}
 }

--- a/HateoasNet/Resources/PaginationResource.cs
+++ b/HateoasNet/Resources/PaginationResource.cs
@@ -1,43 +1,47 @@
 ﻿using HateoasNet.Abstractions;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace HateoasNet.Resources
 {
-    /// ///
     /// <summary>
-    ///   Represents an formatted pagination wrapper of <see cref="Resource" /> wrapper items which inherit from
-    ///   <see cref="Resource" />.
+    ///   Represents a formatted pagination wrapper of <see cref="Resource" /> items.
     /// </summary>
-    public class PaginationResource : Resource
+    [System.Serializable]
+    public class PaginationResource : Resource, IPagination<Resource>
     {
-        public PaginationResource(IPagination<Resource> values) : base(values.Data)
+        public PaginationResource(IEnumerable<Resource> items, long count, int pageSize, int page) : base(items)
         {
-            EnumerableData = values.Data;
-            Count = values.Count;
-            PageSize = values.PageSize;
-            Page = values.Page;
-        }
-
-        public PaginationResource(IEnumerable<Resource> data, long count, int pageSize, int page) : base(data)
-        {
-            EnumerableData = data.ToList();
+            _items = items.ToList();
             Count = count;
             PageSize = pageSize;
             Page = page;
         }
 
-        internal IEnumerable<Resource> EnumerableData { get; }
+        private readonly List<Resource> _items;
 
         /// <summary>
-        ///   The <see cref="IEnumerable{Resource}" /> items as <see langword="object" />.
+        ///   The <see cref="Resource.Data"/> property overriden with actual value being
+        ///   <see cref="IEnumerable{T}" /> of <see cref="Resource"/> items as <see langword="object"/>.
         /// </summary>
-        public override object Data => EnumerableData;
+        public override object Data => GetItems();
+        public virtual int InPage => GetItems().Count();
+        public virtual int Page { get; }
+        public virtual int PageSize { get; }
+        public virtual long Count { get; }
+        public virtual int Pages => (int)(Count == 0 ? 1 : (Count + PageSize - 1) / PageSize);
 
-        public int InPage => EnumerableData.Count();
-        public int Page { get; }
-        public int PageSize { get; }
-        public long Count { get; }
-        public int Pages => (int)(Count == 0 ? 1 : (Count + PageSize - 1) / PageSize);
+        /// <inheritdoc cref="IPagination{Resource}.GetItems"/>
+        public virtual IEnumerable<Resource> GetItems()
+        {
+            return _items;
+        }
+
+        /// <inheritdoc cref="IPagination.GetItems"/>
+        IEnumerable IPagination.GetItems()
+        {
+            return _items;
+        }
     }
 }

--- a/HateoasNet/Resources/Resource.cs
+++ b/HateoasNet/Resources/Resource.cs
@@ -5,6 +5,7 @@ namespace HateoasNet.Resources
     /// <summary>
     ///   Represents a formatted wrapper of requested data in addition to HATEOAS <see cref="Links" />.
     /// </summary>
+    [System.Serializable]
     public abstract class Resource
     {
         protected Resource(object data)
@@ -20,6 +21,6 @@ namespace HateoasNet.Resources
         /// <summary>
         ///   Additional <see cref="List{T}" /> as HATEOAS data.
         /// </summary>
-        public List<ResourceLink> Links { get; } = new List<ResourceLink>();
+        public virtual List<ResourceLink> Links { get; } = new List<ResourceLink>();
     }
 }

--- a/HateoasNet/Resources/Resource.cs
+++ b/HateoasNet/Resources/Resource.cs
@@ -1,17 +1,18 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace HateoasNet.Resources
 {
     /// <summary>
     ///   Represents a formatted wrapper of requested data in addition to HATEOAS <see cref="Links" />.
     /// </summary>
-    [System.Serializable]
-    public abstract class Resource
-    {
-        protected Resource(object data)
-        {
-            Data = data;
-        }
+    [Serializable]
+	public abstract class Resource
+	{
+		protected Resource(object data)
+		{
+			Data = data;
+		}
 
         /// <summary>
         ///   Requested original data
@@ -22,5 +23,5 @@ namespace HateoasNet.Resources
         ///   Additional <see cref="List{T}" /> as HATEOAS data.
         /// </summary>
         public virtual List<ResourceLink> Links { get; } = new List<ResourceLink>();
-    }
+	}
 }

--- a/HateoasNet/Resources/ResourceLink.cs
+++ b/HateoasNet/Resources/ResourceLink.cs
@@ -1,18 +1,20 @@
-﻿namespace HateoasNet.Resources
+﻿using System;
+
+namespace HateoasNet.Resources
 {
     /// <summary>
-    ///   Represents an item of <see cref="Resource.Links" /> holding a <see cref="Rel"/>,
-    ///   <see cref="Href"/> and <see cref="Method"/>.
+    ///   Represents an item of <see cref="Resource.Links" /> holding a <see cref="Rel" />,
+    ///   <see cref="Href" /> and <see cref="Method" />.
     /// </summary>
-    [System.Serializable]
-    public class ResourceLink
-    {
-        public ResourceLink(string rel, string href, string method)
-        {
-            Rel = rel;
-            Href = href;
-            Method = method;
-        }
+    [Serializable]
+	public class ResourceLink
+	{
+		public ResourceLink(string rel, string href, string method)
+		{
+			Rel = rel;
+			Href = href;
+			Method = method;
+		}
 
         /// <summary>
         ///   The Url to access some available action of the <see cref="Resource" /> containing this
@@ -33,5 +35,5 @@
         /// </summary>
         /// <value>The <see langword="string" /> value of HTTP method.</value>
         public virtual string Method { get; } = string.Empty;
-    }
+	}
 }

--- a/HateoasNet/Resources/ResourceLink.cs
+++ b/HateoasNet/Resources/ResourceLink.cs
@@ -1,8 +1,10 @@
 ﻿namespace HateoasNet.Resources
 {
     /// <summary>
-    ///   Represents a HATEOAS link witch is an item of <see cref="Resource.Links" />.
+    ///   Represents an item of <see cref="Resource.Links" /> holding a <see cref="Rel"/>,
+    ///   <see cref="Href"/> and <see cref="Method"/>.
     /// </summary>
+    [System.Serializable]
     public class ResourceLink
     {
         public ResourceLink(string rel, string href, string method)
@@ -13,23 +15,23 @@
         }
 
         /// <summary>
-        ///   The Url link address to access some available action of the <see cref="Resource" /> containing this
+        ///   The Url to access some available action of the <see cref="Resource" /> containing this
         ///   <see cref="ResourceLink" />.
         /// </summary>
         /// <value>Url <see langword="string" /> value.</value>
-        public string Href { get; }
+        public virtual string Href { get; } = string.Empty;
 
         /// <summary>
         ///   The name assigned to the action available for <see cref="Resource" /> containing this <see cref="ResourceLink" />.
         /// </summary>
         /// <value>The <see langword="string" /> value of assigned <see cref="Rel" />.</value>
-        public string Rel { get; }
+        public virtual string Rel { get; } = string.Empty;
 
         /// <summary>
         ///   The HTTP method used to access the action available for <see cref="Resource" /> containing this
         ///   <see cref="ResourceLink" />.
         /// </summary>
         /// <value>The <see langword="string" /> value of HTTP method.</value>
-        public string Method { get; }
+        public virtual string Method { get; } = string.Empty;
     }
 }

--- a/HateoasNet/Resources/SingleResource.cs
+++ b/HateoasNet/Resources/SingleResource.cs
@@ -3,6 +3,7 @@
     /// <summary>
     ///   Represents a formatted wrapper of a single requested object in addition to HATEOAS <see cref="Resource.Links" />.
     /// </summary>
+    [System.Serializable]
     public class SingleResource : Resource
     {
         public SingleResource(object data) : base(data)

--- a/HateoasNet/Resources/SingleResource.cs
+++ b/HateoasNet/Resources/SingleResource.cs
@@ -1,13 +1,15 @@
-﻿namespace HateoasNet.Resources
+﻿using System;
+
+namespace HateoasNet.Resources
 {
     /// <summary>
     ///   Represents a formatted wrapper of a single requested object in addition to HATEOAS <see cref="Resource.Links" />.
     /// </summary>
-    [System.Serializable]
-    public class SingleResource : Resource
-    {
-        public SingleResource(object data) : base(data)
-        {
-        }
-    }
+    [Serializable]
+	public class SingleResource : Resource
+	{
+		public SingleResource(object data) : base(data)
+		{
+		}
+	}
 }

--- a/HateoasNet/TestingObjects/GenericTestee.cs
+++ b/HateoasNet/TestingObjects/GenericTestee.cs
@@ -2,9 +2,9 @@
 
 namespace HateoasNet.TestingObjects
 {
-    public class GenericTestee<T> : Testee
-    {
-        public T Nested { get; set; }
-        public List<T> Collection { get; set; } = new List<T>();
-    }
+	public class GenericTestee<T> : Testee
+	{
+		public T Nested { get; set; }
+		public List<T> Collection { get; set; } = new List<T>();
+	}
 }

--- a/HateoasNet/TestingObjects/GenericTesteeResourceConfiguration.cs
+++ b/HateoasNet/TestingObjects/GenericTesteeResourceConfiguration.cs
@@ -1,16 +1,16 @@
-﻿using HateoasNet.Abstractions;
-using System.Linq;
+﻿using System.Linq;
+using HateoasNet.Abstractions;
 
 namespace HateoasNet.TestingObjects
 {
-    public class GenericTesteeResourceConfiguration : IHateoasResourceConfiguration<GenericTestee<object>>
-    {
-        public void Configure(IHateoasResource<GenericTestee<object>> resource)
-        {
-            resource
-                .HasLink("generic-test")
-                .HasRouteData(t => new { id = t.Nested.ToString() })
-                .HasConditional(t => t.Collection.OfType<Testee>().Any());
-        }
-    }
+	public class GenericTesteeResourceConfiguration : IHateoasResourceConfiguration<GenericTestee<object>>
+	{
+		public void Configure(IHateoasResource<GenericTestee<object>> resource)
+		{
+			resource
+				.HasLink("generic-test")
+				.HasRouteData(t => new {id = t.Nested.ToString()})
+				.HasConditional(t => t.Collection.OfType<Testee>().Any());
+		}
+	}
 }

--- a/HateoasNet/TestingObjects/NestedTestee.cs
+++ b/HateoasNet/TestingObjects/NestedTestee.cs
@@ -2,9 +2,9 @@
 
 namespace HateoasNet.TestingObjects
 {
-    public class NestedTestee : Testee
-    {
-        public Testee Nested { get; set; } = new Testee();
-        public ICollection<Testee> Collection { get; set; } = new List<Testee>() { new Testee() };
-    }
+	public class NestedTestee : Testee
+	{
+		public Testee Nested { get; set; } = new Testee();
+		public ICollection<Testee> Collection { get; set; } = new List<Testee> {new Testee()};
+	}
 }

--- a/HateoasNet/TestingObjects/NestedTesteeResourceConfiguration.cs
+++ b/HateoasNet/TestingObjects/NestedTesteeResourceConfiguration.cs
@@ -1,16 +1,16 @@
-﻿using HateoasNet.Abstractions;
-using System.Linq;
+﻿using System.Linq;
+using HateoasNet.Abstractions;
 
 namespace HateoasNet.TestingObjects
 {
-    public class NestedTesteeResourceConfiguration : IHateoasResourceConfiguration<NestedTestee>
-    {
-        public void Configure(IHateoasResource<NestedTestee> resource)
-        {
-            resource
-                .HasLink("nested-test")
-                .HasRouteData(t => new { id = t.Nested.StringValue })
-                .HasConditional(t => t.Collection.Any());
-        }
-    }
+	public class NestedTesteeResourceConfiguration : IHateoasResourceConfiguration<NestedTestee>
+	{
+		public void Configure(IHateoasResource<NestedTestee> resource)
+		{
+			resource
+				.HasLink("nested-test")
+				.HasRouteData(t => new {id = t.Nested.StringValue})
+				.HasConditional(t => t.Collection.Any());
+		}
+	}
 }

--- a/HateoasNet/TestingObjects/Testee.cs
+++ b/HateoasNet/TestingObjects/Testee.cs
@@ -1,20 +1,21 @@
 ﻿using System;
+
 namespace HateoasNet.TestingObjects
 {
-    public class Testee
-    {
-        public Guid Id { get; set; } = Guid.NewGuid();
-        public string StringValue { get; set; } = "test";
-        public bool BoolValue { get; set; } = true;
-        public int IntegerValue { get; set; } = 100;
-        public long LongIntegerValue { get; set; } = 549587541536;
-        public decimal DecimalValue { get; set; } = 3289.57m;
-        public float FloatValue { get; set; } = 100f;
-        public DateTime CreatedDate { get; set; } = DateTime.UtcNow;
+	public class Testee
+	{
+		public Guid Id { get; set; } = Guid.NewGuid();
+		public string StringValue { get; set; } = "test";
+		public bool BoolValue { get; set; } = true;
+		public int IntegerValue { get; set; } = 100;
+		public long LongIntegerValue { get; set; } = 549587541536;
+		public decimal DecimalValue { get; set; } = 3289.57m;
+		public float FloatValue { get; set; } = 100f;
+		public DateTime CreatedDate { get; set; } = DateTime.UtcNow;
 
-        public override string ToString()
-        {
-            return StringValue;
-        }
-    }
+		public override string ToString()
+		{
+			return StringValue;
+		}
+	}
 }

--- a/HateoasNet/TestingObjects/TesteeResourceConfiguration.cs
+++ b/HateoasNet/TestingObjects/TesteeResourceConfiguration.cs
@@ -2,14 +2,14 @@
 
 namespace HateoasNet.TestingObjects
 {
-    public class TesteeResourceConfiguration : IHateoasResourceConfiguration<Testee>
-    {
-        public void Configure(IHateoasResource<Testee> resource)
-        {
-            resource
-                .HasLink("test")
-                .HasRouteData(t => new { id = t.StringValue })
-                .HasConditional(t => t.BoolValue);
-        }
-    }
+	public class TesteeResourceConfiguration : IHateoasResourceConfiguration<Testee>
+	{
+		public void Configure(IHateoasResource<Testee> resource)
+		{
+			resource
+				.HasLink("test")
+				.HasRouteData(t => new {id = t.StringValue})
+				.HasConditional(t => t.BoolValue);
+		}
+	}
 }


### PR DESCRIPTION
All public members of classes under Resource hierarchy were turned virtual:
- Allowing custom attributes (for serialization control, etc)
- Custom behaviours from client-code;
- Usage as base models for extended custom implementations.

Default HateoasSerializers accepting optional custom settings:
- JsonSerializerOptions on Net Core implementation using System.Text.Json, having methods for managing custom JsonConverters instead of default GuidConverter and DateTimeConverter, due to System.Text.Json current limitations serializing these kinds of values.;
- JsonSerializerSettings on Net Framework with Newtonsoft.Json with support for managing custom converters through the Newtonsoft resources.

The HateoasContext no more implements IDisposable:
- Verified there is no presence of unmanaged code during configuration, It shows off no need for being IDisposable.