### PR TITLE
Allow IHateoas to generate links without type parameter

### DIFF
--- a/HateoasNet/AbstractHateoas.cs
+++ b/HateoasNet/AbstractHateoas.cs
@@ -12,7 +12,7 @@ namespace HateoasNet
             _hateoas = hateoas;
         }
 
-        public TOutput Generate<TSource>(TSource source)
+        public TOutput Generate(object source)
         {
             return GenerateCustom(_hateoas.Generate(source));
         }

--- a/HateoasNet/Abstractions/IHateoasContext.cs
+++ b/HateoasNet/Abstractions/IHateoasContext.cs
@@ -11,12 +11,11 @@ namespace HateoasNet.Abstractions
     {
         /// <summary>
         ///   Gets all applicable <see cref="IHateoasLinkBuilder" /> from a <see cref="IHateoasSource{T}" /> configuration
-        ///   of <typeparamref name="T" /> using <paramref name="source" /> to evaluate the applicability.
+        ///   for the <see cref="Type"/> of <paramref name="source" /> to evaluate the applicability.
         /// </summary>
         /// <param name="source">An object used to evaluate the applicability.</param>
-        /// <typeparam name="T">Type to look for <see cref="IHateoasSource{T}" /> associated.</typeparam>
         /// <returns><see cref="IEnumerable{IHateoasLink}" /> with all applicable <see cref="IHateoasLinkBuilder" />.</returns>
-        IEnumerable<IHateoasLinkBuilder> GetApplicableLinkBuilders<T>(T source);
+        IEnumerable<IHateoasLinkBuilder> GetApplicableLinkBuilders(object source);
 
         /// <summary>
         ///   Adds or continues an <see cref="IHateoasSource{T}" /> configuration of <typeparamref name="T" /> 

--- a/HateoasNet/Hateoas.cs
+++ b/HateoasNet/Hateoas.cs
@@ -24,7 +24,7 @@ namespace HateoasNet
     {
         private readonly IHateoasContext _context;
 
-        public IEnumerable<HateoasLink> Generate<T>(T source)
+        public IEnumerable<HateoasLink> Generate(object source)
         {
             foreach (var linkBuilder in _context.GetApplicableLinkBuilders(source))
             {

--- a/HateoasNet/IHateoas.cs
+++ b/HateoasNet/IHateoas.cs
@@ -9,12 +9,11 @@ namespace HateoasNet
     {
         /// <summary>
         ///   Gets available collection of <see cref="HateoasLink"/> using <see cref="IHateoasSource{T}" /> configuration
-        ///   of <typeparamref name="T" /> with <paramref name="source" /> as original value.
+        ///   for the <see cref="Type"/> of <paramref name="source" /> given as original value.
         /// </summary>
         /// <param name="source">Original value to look for mapped links.</param>
-        /// <typeparam name="T">type parameter of <see cref="IHateoasSource{T}" />  configuration.</typeparam>
-        /// <returns>A <see cref="IEnumerable{T}" /> of <see cref="HateoasLink"/> ietms.</returns>
-        IEnumerable<HateoasLink> Generate<T>(T source);
+        /// <returns>A <see cref="IEnumerable{T}" /> of <see cref="HateoasLink"/> items.</returns>
+        IEnumerable<HateoasLink> Generate(object source);
     }
 
     /// <summary>
@@ -24,11 +23,10 @@ namespace HateoasNet
     {
         /// <summary>
         ///   Gets <typeparamref name="TOutput"/> value transformed from available collection of <see cref="HateoasLink"/> using <see cref="IHateoasSource{T}" />
-        ///   configuration of <typeparamref name="TSource" /> with <paramref name="source" /> as original value.
+        ///   configuration for the <see cref="Type"/> of <paramref name="source" /> given as original value.
         /// </summary>
         /// <param name="source">Original value to look for mapped links.</param>
-        /// <typeparam name="TSource">type parameter of <see cref="IHateoasSource{T}" />  configuration.</typeparam>
         /// <returns>A custom <see cref="TOutput"/> created from <see cref="IEnumerable{T}" /> of <see cref="HateoasLink"/> ietms.</returns>
-        TOutput Generate<TSource>(TSource source);
+        TOutput Generate(object source);
     }
 }

--- a/HateoasNet/Infrastructure/HateoasContext.cs
+++ b/HateoasNet/Infrastructure/HateoasContext.cs
@@ -17,11 +17,11 @@ namespace HateoasNet.Infrastructure
         {
         }
 
-        public IEnumerable<IHateoasLinkBuilder> GetApplicableLinkBuilders<T>(T source)
+        public IEnumerable<IHateoasLinkBuilder> GetApplicableLinkBuilders(object source)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
 
-            return _sources.TryGetValue(typeof(T), out var hateoasSource)
+            return _sources.TryGetValue(source.GetType(), out var hateoasSource)
                 ? hateoasSource?.GetLinkBuilders().Where(link => link.IsApplicable(source)).ToList()
                 : new List<IHateoasLinkBuilder>();
         }


### PR DESCRIPTION
Replacing signatures using a type parameter for method `IHateoas.Generate<T>(T source)` by `IHateoas.Generate(object source)` and method `IHateoas<TOut>.Generate<TSource>(TSource source)` by `IHateoas<TOut>.Generate(object source)`, allowing typeless calls for the generation of HATEOAS links.